### PR TITLE
Rename header to column for clarity

### DIFF
--- a/examples/dimensions/main.go
+++ b/examples/dimensions/main.go
@@ -19,11 +19,11 @@ type Model struct {
 }
 
 func genTable(columnCount int, rowCount int) table.Model {
-	headers := []table.Header{}
+	columns := []table.Column{}
 
 	for column := 0; column < columnCount; column++ {
 		columnStr := fmt.Sprintf("%d", column+1)
-		headers = append(headers, table.NewHeader(columnStr, columnStr, 4))
+		columns = append(columns, table.NewColumn(columnStr, columnStr, 4))
 	}
 
 	rows := []table.Row{}
@@ -39,7 +39,7 @@ func genTable(columnCount int, rowCount int) table.Model {
 		rows = append(rows, table.NewRow(rowData))
 	}
 
-	return table.New(headers).WithRows(rows).HeaderStyle(lipgloss.NewStyle().Bold(true))
+	return table.New(columns).WithRows(rows).HeaderStyle(lipgloss.NewStyle().Bold(true))
 }
 
 func NewModel() Model {

--- a/examples/features/main.go
+++ b/examples/features/main.go
@@ -46,11 +46,11 @@ type Model struct {
 }
 
 func NewModel() Model {
-	headers := []table.Header{
-		table.NewHeader(columnKeyID, "ID", 5),
-		table.NewHeader(columnKeyName, "Name", 10),
-		table.NewHeader(columnKeyDescription, "Description", 30),
-		table.NewHeader(columnKeyCount, "#", 5),
+	columns := []table.Column{
+		table.NewColumn(columnKeyID, "ID", 5),
+		table.NewColumn(columnKeyName, "Name", 10),
+		table.NewColumn(columnKeyDescription, "Description", 30),
+		table.NewColumn(columnKeyCount, "#", 5),
 	}
 
 	rows := []table.Row{
@@ -75,7 +75,7 @@ func NewModel() Model {
 	}
 
 	return Model{
-		tableModel: table.New(headers).
+		tableModel: table.New(columns).
 			WithRows(rows).
 			HeaderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)).
 			SelectableRows(true).

--- a/table/border.go
+++ b/table/border.go
@@ -242,6 +242,8 @@ func (b *Border) generateStyles() {
 	)
 }
 
+// BorderDefault uses the basic square border, useful to reset the border if
+// it was changed somehow
 func (m Model) BorderDefault() Model {
 	// Already generated styles
 	m.border = borderDefault
@@ -249,6 +251,7 @@ func (m Model) BorderDefault() Model {
 	return m
 }
 
+// Border uses the given border components to render the table
 func (m Model) Border(border Border) Model {
 	border.generateStyles()
 

--- a/table/column.go
+++ b/table/column.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 )
 
-type Header struct {
+// Column is a column in the table
+type Column struct {
 	Title string
 	Key   string
 	Width int
@@ -12,8 +13,9 @@ type Header struct {
 	fmtString string
 }
 
-func NewHeader(key, title string, width int) Header {
-	return Header{
+// NewColumn creates a new column with the given information
+func NewColumn(key, title string, width int) Column {
+	return Column{
 		Key:       key,
 		Title:     title,
 		Width:     width,

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -18,12 +18,12 @@ func TestBasicTableShowsAllHeaders(t *testing.T) {
 		secondWidth = 20
 	)
 
-	headers := []Header{
-		NewHeader(firstKey, firstTitle, firstWidth),
-		NewHeader(secondKey, secondTitle, secondWidth),
+	columns := []Column{
+		NewColumn(firstKey, firstTitle, firstWidth),
+		NewColumn(secondKey, secondTitle, secondWidth),
 	}
 
-	table := New(headers)
+	table := New(columns)
 
 	rendered := table.View()
 
@@ -33,7 +33,7 @@ func TestBasicTableShowsAllHeaders(t *testing.T) {
 	assert.False(t, strings.HasSuffix(rendered, "\n"), "Should not end in newline")
 }
 
-func TestNilHeadersSafelyReturnsEmptyView(t *testing.T) {
+func TestNilColumnsSafelyReturnsEmptyView(t *testing.T) {
 	table := New(nil)
 
 	assert.Equal(t, "", table.View())


### PR DESCRIPTION
'Header' was a mental shortcut name that is unclear.  These are actually columns, so call them columns.