### PR TITLE
Fix selection

### DIFF
--- a/table/update.go
+++ b/table/update.go
@@ -30,16 +30,16 @@ func (m *Model) toggleSelect() {
 		return
 	}
 
-	rows := make([]Row, len(m.rows))
-	copy(rows, m.rows)
+	rows := make([]Row, len(m.sortedRows))
+	copy(rows, m.sortedRows)
 
 	rows[m.rowCursorIndex].selected = !rows[m.rowCursorIndex].selected
 
-	m.rows = rows
+	m.sortedRows = rows
 
 	m.selectedRows = []Row{}
 
-	for _, row := range m.rows {
+	for _, row := range m.sortedRows {
 		if row.selected {
 			m.selectedRows = append(m.selectedRows, row)
 		}

--- a/table/update_test.go
+++ b/table/update_test.go
@@ -192,15 +192,15 @@ func TestSelectingRowToggles(t *testing.T) {
 	keyEnter := tea.KeyMsg{Type: tea.KeyEnter}
 	keyDown := tea.KeyMsg{Type: tea.KeyDown}
 
-	assert.False(t, model.rows[0].selected, "Row shouldn't be selected to start")
+	assert.False(t, model.sortedRows[0].selected, "Row shouldn't be selected to start")
 
 	model, _ = model.Update(keyEnter)
-	assert.True(t, model.rows[0].selected, "Row should be selected after first toggle")
+	assert.True(t, model.sortedRows[0].selected, "Row should be selected after first toggle")
 
 	model, _ = model.Update(keyEnter)
-	assert.False(t, model.rows[0].selected, "Row should not be selected after second toggle")
+	assert.False(t, model.sortedRows[0].selected, "Row should not be selected after second toggle")
 
 	model, _ = model.Update(keyDown)
 	model, _ = model.Update(keyEnter)
-	assert.True(t, model.rows[1].selected, "Second row should be selected after moving and toggling")
+	assert.True(t, model.sortedRows[1].selected, "Second row should be selected after moving and toggling")
 }


### PR DESCRIPTION
Selection was broken by the sort functionality.  This is a quick fix since #29 will adjust how sorted rows are stored in the back-end.