### PR TITLE
Fix string length limiting for double-width characters

### DIFF
--- a/examples/flex/main.go
+++ b/examples/flex/main.go
@@ -36,11 +36,9 @@ func NewModel() Model {
 				columnKeyDescription: "Super zappy mouse, handle with care",
 			}),
 			table.NewRow(table.RowData{
-				columnKeyName:    "Charmander",
-				columnKeyElement: "Fire",
-				// TODO: Fix double width string length limiting!
-				//columnKeyDescription: "直立した恐竜のような身体と、尻尾の先端に常に燃えている炎が特徴。",
-				columnKeyDescription: "Lots of fire",
+				columnKeyName:        "Charmander",
+				columnKeyElement:     "Fire",
+				columnKeyDescription: "直立した恐竜のような身体と、尻尾の先端に常に燃えている炎が特徴。",
 			}),
 		}),
 	}

--- a/table/strlimit.go
+++ b/table/strlimit.go
@@ -1,12 +1,13 @@
 package table
 
+import "github.com/mattn/go-runewidth"
+
 func limitStr(str string, maxLen int) string {
 	if maxLen == 0 {
 		return ""
 	}
-
-	if len([]rune(str)) > maxLen {
-		return string([]rune(str)[:maxLen-1]) + "…"
+	if runewidth.StringWidth(str) > maxLen {
+		return runewidth.Truncate(str, maxLen-1, "") + "…"
 	}
 
 	return str

--- a/table/strlimit_test.go
+++ b/table/strlimit_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// This function is only long because of repetitive test definitions, this is fine
+// nolint: funlen
 func TestLimitStr(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -55,6 +57,18 @@ func TestLimitStr(t *testing.T) {
 			input:    "✓✓✓",
 			max:      2,
 			expected: "✓…",
+		},
+		{
+			name:     "Unicode japenese equal",
+			input:    "直立",
+			max:      5,
+			expected: "直立",
+		},
+		{
+			name:     "Unicode japenese truncated",
+			input:    "直立した恐",
+			max:      5,
+			expected: "直立…",
 		},
 	}
 


### PR DESCRIPTION
https://github.com/Evertras/bubble-table/issues/40
Implemented the go-runewidth library to manage runes truncation
Added tests for japanese characters