### PR TITLE
Fix table layout for multi-line values - fixes issue #51

### DIFF
--- a/table/strlimit.go
+++ b/table/strlimit.go
@@ -1,13 +1,27 @@
 package table
 
-import "github.com/mattn/go-runewidth"
+import (
+	"strings"
+
+	"github.com/mattn/go-runewidth"
+)
 
 func limitStr(str string, maxLen int) string {
 	if maxLen == 0 {
 		return ""
 	}
+
+	newLineIndex := strings.Index(str, "\n")
+	if newLineIndex > -1 {
+		str = str[:newLineIndex]
+	}
+
 	if runewidth.StringWidth(str) > maxLen {
 		return runewidth.Truncate(str, maxLen-1, "") + "…"
+	}
+
+	if newLineIndex > -1 {
+		return str + "…"
 	}
 
 	return str

--- a/table/strlimit_test.go
+++ b/table/strlimit_test.go
@@ -70,6 +70,12 @@ func TestLimitStr(t *testing.T) {
 			max:      5,
 			expected: "直立…",
 		},
+		{
+			name:     "multiline truncated",
+			input:    "hi\nall",
+			max:      5,
+			expected: "hi…",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
If one of the rows has a multi-line value we want
to truncate it and display one the first line