### PR TITLE
Fix edge case for multiline truncation on exact max length

### DIFF
--- a/table/strlimit.go
+++ b/table/strlimit.go
@@ -13,15 +13,11 @@ func limitStr(str string, maxLen int) string {
 
 	newLineIndex := strings.Index(str, "\n")
 	if newLineIndex > -1 {
-		str = str[:newLineIndex]
+		str = str[:newLineIndex] + "…"
 	}
 
 	if runewidth.StringWidth(str) > maxLen {
 		return runewidth.Truncate(str, maxLen-1, "") + "…"
-	}
-
-	if newLineIndex > -1 {
-		return str + "…"
 	}
 
 	return str

--- a/table/strlimit_test.go
+++ b/table/strlimit_test.go
@@ -71,10 +71,16 @@ func TestLimitStr(t *testing.T) {
 			expected: "直立…",
 		},
 		{
-			name:     "multiline truncated",
+			name:     "Multiline truncated",
 			input:    "hi\nall",
 			max:      5,
 			expected: "hi…",
+		},
+		{
+			name:     "Multiline with exact max width",
+			input:    "hello\nall",
+			max:      5,
+			expected: "hell…",
 		},
 	}
 


### PR DESCRIPTION
Fixes the edge case remaining for #51 where in a multiline string, if the first line was exactly the max width, the extra added character would break the format.