### PR TITLE
Bound current page when WithRows is called with fewer rows

### DIFF
--- a/table/options.go
+++ b/table/options.go
@@ -32,6 +32,15 @@ func (m Model) HeaderStyle(style lipgloss.Style) Model {
 func (m Model) WithRows(rows []Row) Model {
 	m.rows = rows
 
+	if m.pageSize != 0 {
+		maxPage := m.MaxPages()
+
+		// MaxPages is 1-index, currentPage is 0 index
+		if maxPage <= m.currentPage {
+			m.pageLast()
+		}
+	}
+
 	return m
 }
 

--- a/table/pagination.go
+++ b/table/pagination.go
@@ -82,19 +82,11 @@ func (m *Model) pageUp() {
 }
 
 func (m *Model) pageFirst() {
-	if m.pageSize == 0 || len(m.GetVisibleRows()) <= m.pageSize {
-		return
-	}
-
 	m.currentPage = 0
 	m.rowCursorIndex = 0
 }
 
 func (m *Model) pageLast() {
-	if m.pageSize == 0 || len(m.GetVisibleRows()) <= m.pageSize {
-		return
-	}
-
 	m.currentPage = m.MaxPages() - 1
 	m.rowCursorIndex = m.currentPage * m.pageSize
 }

--- a/table/pagination_test.go
+++ b/table/pagination_test.go
@@ -363,3 +363,28 @@ func TestClearPagination(t *testing.T) {
 
 	assert.Equal(t, 0, model.expectedPageForRowIndex(11))
 }
+
+func TestPaginationSetsLastPageWithFewerRows(t *testing.T) {
+	const (
+		pageSize        = 10
+		numRowsOriginal = 30
+		numRowsAfter    = 18
+	)
+
+	model := genPaginationTable(numRowsOriginal, pageSize)
+	model.pageUp()
+
+	assert.Equal(t, 3, model.CurrentPage())
+
+	rows := []Row{}
+
+	for i := 1; i <= numRowsAfter; i++ {
+		rows = append(rows, NewRow(RowData{
+			"id": i,
+		}))
+	}
+
+	model = model.WithRows(rows)
+
+	assert.Equal(t, 2, model.CurrentPage())
+}


### PR DESCRIPTION
Before, if `WithRows` was called with a paginated table, and the row count was less such that the user would be on a page that no longer exists, they would see no data and have to try and navigate again.  After this change, `WithRows` will trigger a check to bound the current page to the maximum page, so that they will be put on the last page.