### PR TITLE
Add shortcut to clear filter and escape filtering

### DIFF
--- a/examples/filter/main.go
+++ b/examples/filter/main.go
@@ -71,7 +71,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "esc", "q":
+		case "ctrl+c", "q":
 			cmds = append(cmds, tea.Quit)
 		}
 
@@ -84,7 +84,7 @@ func (m Model) View() string {
 	body := strings.Builder{}
 
 	body.WriteString("A filtered simple default table\n" +
-		"Currently filter by Title and Author, press / to filter.\nPress q or ctrl+c to quit\n\n")
+		"Currently filter by Title and Author, press / + letters to start filtering, and escape to clear filter.\nPress q or ctrl+c to quit\n\n")
 
 	body.WriteString(m.table.View())
 

--- a/table/keys.go
+++ b/table/keys.go
@@ -14,7 +14,8 @@ type KeyMap struct {
 	PageFirst key.Binding
 	PageLast  key.Binding
 
-	Filter key.Binding
+	Filter      key.Binding
+	FilterClear key.Binding
 }
 
 // DefaultKeyMap returns a set of sensible defaults for controlling a focused table.
@@ -43,6 +44,9 @@ func DefaultKeyMap() KeyMap {
 		),
 		Filter: key.NewBinding(
 			key.WithKeys("/"),
+		),
+		FilterClear: key.NewBinding(
+			key.WithKeys("esc"),
 		),
 	}
 }

--- a/table/keys.go
+++ b/table/keys.go
@@ -14,7 +14,13 @@ type KeyMap struct {
 	PageFirst key.Binding
 	PageLast  key.Binding
 
-	Filter      key.Binding
+	// Filter allows the user to start typing and filter the rows.
+	Filter key.Binding
+
+	// FilterBlur is the key that stops the user's input from typing into the filter.
+	FilterBlur key.Binding
+
+	// FilterClear will clear the filter while it's blurred.
 	FilterClear key.Binding
 }
 
@@ -44,6 +50,9 @@ func DefaultKeyMap() KeyMap {
 		),
 		Filter: key.NewBinding(
 			key.WithKeys("/"),
+		),
+		FilterBlur: key.NewBinding(
+			key.WithKeys("enter", "esc"),
 		),
 		FilterClear: key.NewBinding(
 			key.WithKeys("esc"),

--- a/table/update.go
+++ b/table/update.go
@@ -50,7 +50,7 @@ func (m Model) updateFilterTextInput(msg tea.Msg) (Model, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		if msg.Type == tea.KeyEnter {
+		if msg.Type == tea.KeyEnter || msg.Type == tea.KeyEscape {
 			m.filterTextInput.Blur()
 		}
 	}
@@ -84,6 +84,9 @@ func (m *Model) handleKeypress(msg tea.KeyMsg) {
 
 	case key.Matches(msg, m.keyMap.Filter):
 		m.filterTextInput.Focus()
+
+	case key.Matches(msg, m.keyMap.FilterClear):
+		m.filterTextInput.Reset()
 	}
 }
 

--- a/table/update.go
+++ b/table/update.go
@@ -50,7 +50,7 @@ func (m Model) updateFilterTextInput(msg tea.Msg) (Model, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		if msg.Type == tea.KeyEnter || msg.Type == tea.KeyEscape {
+		if key.Matches(msg, m.keyMap.FilterBlur) {
 			m.filterTextInput.Blur()
 		}
 	}

--- a/table/update_test.go
+++ b/table/update_test.go
@@ -293,6 +293,10 @@ func TestFilterWithKeypresses(t *testing.T) {
 		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	}
 
+	hitEscape := func() {
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	}
+
 	visible := model.GetVisibleRows()
 
 	assert.Len(t, visible, 2)
@@ -310,5 +314,13 @@ func TestFilterWithKeypresses(t *testing.T) {
 
 	hitKey('x')
 
+	visible = model.GetVisibleRows()
+
 	assert.Len(t, visible, 1)
+
+	hitEscape()
+
+	visible = model.GetVisibleRows()
+
+	assert.Len(t, visible, 2)
 }


### PR DESCRIPTION
Escape key will now exit filtering, as well as clear the filter if not currently actively typing in the filter.  Clearing the filter is a configurable keymap.

This is theoretically a breaking change if someone was using the escape key along with table filtering and expected some other behavior, but this seems incredibly unlikely and the keymap can be redone in their application if this is the case.