### PR TITLE
Use muesli/reflow to compute str width & truncate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/charmbracelet/bubbles v0.10.3
 	github.com/charmbracelet/bubbletea v0.19.3
 	github.com/charmbracelet/lipgloss v0.4.0
+	github.com/mattn/go-runewidth v0.0.13
+	github.com/muesli/reflow v0.3.0
 	github.com/stretchr/testify v1.7.0
 )
 
@@ -15,9 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.13 // indirect
-	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
-	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.9.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/table/strlimit.go
+++ b/table/strlimit.go
@@ -3,7 +3,8 @@ package table
 import (
 	"strings"
 
-	"github.com/mattn/go-runewidth"
+	"github.com/muesli/reflow/ansi"
+	"github.com/muesli/reflow/truncate"
 )
 
 func limitStr(str string, maxLen int) string {
@@ -16,8 +17,8 @@ func limitStr(str string, maxLen int) string {
 		str = str[:newLineIndex] + "…"
 	}
 
-	if runewidth.StringWidth(str) > maxLen {
-		return runewidth.Truncate(str, maxLen-1, "") + "…"
+	if ansi.PrintableRuneWidth(str) > maxLen {
+		return truncate.StringWithTail(str, uint(maxLen), "…")
 	}
 
 	return str

--- a/table/strlimit_test.go
+++ b/table/strlimit_test.go
@@ -2,8 +2,8 @@ package table
 
 import (
 	"testing"
-	"unicode/utf8"
 
+	"github.com/muesli/reflow/ansi"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -82,6 +82,18 @@ func TestLimitStr(t *testing.T) {
 			max:      5,
 			expected: "hell…",
 		},
+		{
+			name:     "Embedded ANSI control sequences with exact max width",
+			input:    "\x1b[0m\x1b[0mtest",
+			max:      4,
+			expected: "\x1b[0m\x1b[0mtest",
+		},
+		{
+			name:     "Embedded ANSI control sequences with truncation",
+			input:    "\x1b[0m\x1b[0mt\x1b[0me\x1b[0ms\x1b[0mt",
+			max:      3,
+			expected: "\x1b[0m\x1b[0mt\x1b[0me\x1b[0m…",
+		},
 	}
 
 	for _, test := range tests {
@@ -89,7 +101,7 @@ func TestLimitStr(t *testing.T) {
 			output := limitStr(test.input, test.max)
 
 			assert.Equal(t, test.expected, output)
-			assert.LessOrEqual(t, utf8.RuneCountInString(output), test.max)
+			assert.LessOrEqual(t, ansi.PrintableRuneWidth(output), test.max)
 		})
 	}
 }

--- a/table/strlimit_test.go
+++ b/table/strlimit_test.go
@@ -84,15 +84,15 @@ func TestLimitStr(t *testing.T) {
 		},
 		{
 			name:     "Embedded ANSI control sequences with exact max width",
-			input:    "\x1b[0m\x1b[0mtest",
+			input:    "\x1b[31;41mtest\x1b[0m",
 			max:      4,
-			expected: "\x1b[0m\x1b[0mtest",
+			expected: "\x1b[31;41mtest\x1b[0m",
 		},
 		{
 			name:     "Embedded ANSI control sequences with truncation",
-			input:    "\x1b[0m\x1b[0mt\x1b[0me\x1b[0ms\x1b[0mt",
+			input:    "\x1b[31;41mte\x1b[0m\x1b[0m\x1b[0mst",
 			max:      3,
-			expected: "\x1b[0m\x1b[0mt\x1b[0me\x1b[0m…",
+			expected: "\x1b[31;41mte\x1b[0m\x1b[0m\x1b[0m…",
 		},
 	}
 


### PR DESCRIPTION
PR related to #66.

Based on [this comment](https://github.com/Evertras/bubble-table/issues/66#issuecomment-1113884401) I looked in the muesli/reflow library for utilities to compute string width & do truncation while accounting for ANSI control sequences.

I would be happy to resubmit this PR using lipgloss instead if you'd prefer.