### PR TITLE
fix: remove confusing naming visible

### DIFF
--- a/examples/pagination/main.go
+++ b/examples/pagination/main.go
@@ -116,7 +116,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	cmds = append(cmds, cmd)
 
 	// Write a custom footer
-	start, end := m.tableWithRowIndices.VisibleIndices()
+	start, end := m.tableWithRowIndices.AvailableIndices()
 	m.tableWithRowIndices = m.tableWithRowIndices.WithStaticFooter(
 		fmt.Sprintf("%d-%d of %d", start+1, end+1, m.tableWithRowIndices.TotalRows()),
 	)

--- a/table/border.go
+++ b/table/border.go
@@ -322,7 +322,7 @@ func (b *borderStyleRow) inherit(s lipgloss.Style) {
 // harder to follow.  So just be careful with comments and make sure it's tested!
 // nolint:nestif
 func (m Model) styleHeaders() borderStyleRow {
-	hasRows := len(m.GetVisibleRows()) > 0
+	hasRows := len(m.GetAvailableRows()) > 0
 	singleColumn := len(m.columns) == 1
 	styles := borderStyleRow{}
 

--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -157,7 +157,7 @@ func TestGetFilteredRowsRefocusAfterFilter(t *testing.T) {
 	}
 	model := New(columns).WithRows(rows).Filtered(true).WithPageSize(1)
 	model = model.PageDown()
-	assert.Len(t, model.GetVisibleRows(), 5)
+	assert.Len(t, model.GetAvailableRows(), 5)
 	assert.Equal(t, 1, model.PageSize())
 	assert.Equal(t, 2, model.CurrentPage())
 	assert.Equal(t, 5, model.MaxPages())
@@ -165,7 +165,7 @@ func TestGetFilteredRowsRefocusAfterFilter(t *testing.T) {
 
 	model.filterTextInput.SetValue("c")
 	model, _ = model.updateFilterTextInput(tea.KeyMsg{})
-	assert.Len(t, model.GetVisibleRows(), 1)
+	assert.Len(t, model.GetAvailableRows(), 1)
 	assert.Equal(t, 1, model.PageSize())
 	assert.Equal(t, 1, model.CurrentPage())
 	assert.Equal(t, 1, model.MaxPages())
@@ -173,7 +173,7 @@ func TestGetFilteredRowsRefocusAfterFilter(t *testing.T) {
 
 	model.filterTextInput.SetValue("not-exist")
 	model, _ = model.updateFilterTextInput(tea.KeyMsg{})
-	assert.Len(t, model.GetVisibleRows(), 0)
+	assert.Len(t, model.GetAvailableRows(), 0)
 	assert.Equal(t, 1, model.PageSize())
 	assert.Equal(t, 1, model.CurrentPage())
 	assert.Equal(t, 1, model.MaxPages())

--- a/table/model.go
+++ b/table/model.go
@@ -87,8 +87,15 @@ func (m Model) Init() tea.Cmd {
 	return nil
 }
 
-// GetVisibleRows return sorted and filtered rows.
+// GetVisibleRows is the legacy name of GetAvailableRows
+// you should use GetAvailableRows instead.
+// TODO: remove this in a future release.
 func (m Model) GetVisibleRows() []Row {
+	return m.GetAvailableRows()
+}
+
+// GetAvailableRows return sorted and filtered rows.
+func (m Model) GetAvailableRows() []Row {
 	rows := make([]Row, len(m.rows))
 	copy(rows, m.rows)
 	if m.filtered {

--- a/table/model_test.go
+++ b/table/model_test.go
@@ -15,7 +15,7 @@ func TestModelInitReturnsNil(t *testing.T) {
 	assert.Nil(t, cmd)
 }
 
-func TestGetVisibleRows(t *testing.T) {
+func TestGetAvailableRows(t *testing.T) {
 	input := textinput.Model{}
 	input.SetValue("AAA")
 	columns := []Column{NewColumn("title", "title", 10).WithFiltered(true)}
@@ -34,6 +34,6 @@ func TestGetVisibleRows(t *testing.T) {
 		}),
 	}
 	m := Model{filtered: true, filterTextInput: input, columns: columns, rows: rows}
-	visibleRows := m.GetVisibleRows()
-	assert.Len(t, visibleRows, 1)
+	availableRows := m.GetAvailableRows()
+	assert.Len(t, availableRows, 1)
 }

--- a/table/options.go
+++ b/table/options.go
@@ -12,8 +12,8 @@ func (m Model) WithHighlightedRow(index int) Model {
 		m.rowCursorIndex = 0
 	}
 
-	if m.rowCursorIndex >= len(m.GetVisibleRows()) {
-		m.rowCursorIndex = len(m.GetVisibleRows()) - 1
+	if m.rowCursorIndex >= len(m.GetAvailableRows()) {
+		m.rowCursorIndex = len(m.GetAvailableRows()) - 1
 	}
 
 	m.currentPage = m.expectedPageForRowIndex(m.rowCursorIndex)
@@ -80,8 +80,8 @@ func (m Model) SelectableRows(selectable bool) Model {
 
 // HighlightedRow returns the full Row that's currently highlighted by the user.
 func (m Model) HighlightedRow() Row {
-	if len(m.GetVisibleRows()) > 0 {
-		return m.GetVisibleRows()[m.rowCursorIndex]
+	if len(m.GetAvailableRows()) > 0 {
+		return m.GetAvailableRows()[m.rowCursorIndex]
 	}
 
 	// TODO: Better way to do this without pointers/nil?  Or should it be nil?
@@ -231,7 +231,7 @@ func (m Model) WithCurrentPage(currentPage int) Model {
 	return m
 }
 
-// WithColumns sets the visible columns for the table, so that columns can be
+// WithColumns sets the available columns for the table, so that columns can be
 // added/removed/resized or headers rewritten.
 func (m Model) WithColumns(columns []Column) Model {
 	// Deep copy to avoid edits

--- a/table/pagination.go
+++ b/table/pagination.go
@@ -14,23 +14,30 @@ func (m *Model) CurrentPage() int {
 
 // MaxPages returns the maximum number of pages that are visible.
 func (m *Model) MaxPages() int {
-	if m.pageSize == 0 || len(m.GetVisibleRows()) == 0 {
+	if m.pageSize == 0 || len(m.GetAvailableRows()) == 0 {
 		return 1
 	}
 
-	return (len(m.GetVisibleRows())-1)/m.pageSize + 1
+	return (len(m.GetAvailableRows())-1)/m.pageSize + 1
 }
 
 // TotalRows returns the current total row count of the table.  If the table is
 // paginated, this is the total number of rows across all pages.
 func (m *Model) TotalRows() int {
-	return len(m.GetVisibleRows())
+	return len(m.GetAvailableRows())
 }
 
-// VisibleIndices returns the current visible rows by their 0 based index.
-// Useful for custom pagination footers.
+// VisibleIndices is the legacy name for AvailableIndices.
+// use AvailableIndices instead.
+// TODO: remove this in a future release.
 func (m *Model) VisibleIndices() (start, end int) {
-	totalRows := len(m.GetVisibleRows())
+	return m.AvailableIndices()
+}
+
+// AvailableIndices returns the current visible rows by their 0 based index.
+// Useful for custom pagination footers.
+func (m *Model) AvailableIndices() (start, end int) {
+	totalRows := len(m.GetAvailableRows())
 
 	if m.pageSize == 0 {
 		start = 0
@@ -50,7 +57,7 @@ func (m *Model) VisibleIndices() (start, end int) {
 }
 
 func (m *Model) pageDown() {
-	if m.pageSize == 0 || len(m.GetVisibleRows()) <= m.pageSize {
+	if m.pageSize == 0 || len(m.GetAvailableRows()) <= m.pageSize {
 		return
 	}
 
@@ -66,7 +73,7 @@ func (m *Model) pageDown() {
 }
 
 func (m *Model) pageUp() {
-	if m.pageSize == 0 || len(m.GetVisibleRows()) <= m.pageSize {
+	if m.pageSize == 0 || len(m.GetAvailableRows()) <= m.pageSize {
 		return
 	}
 

--- a/table/pagination_test.go
+++ b/table/pagination_test.go
@@ -32,10 +32,10 @@ func paginationRowID(row Row) int {
 	return rowID
 }
 
-func getVisibleRows(m *Model) []Row {
-	start, end := m.VisibleIndices()
+func getAvailableRows(m *Model) []Row {
+	start, end := m.AvailableIndices()
 
-	return m.GetVisibleRows()[start : end+1]
+	return m.GetAvailableRows()[start : end+1]
 }
 
 func TestPaginationAccessors(t *testing.T) {
@@ -58,7 +58,7 @@ func TestPaginationNoPageSizeReturnsAll(t *testing.T) {
 
 	model := genPaginationTable(numRows, pageSize)
 
-	paginatedRows := getVisibleRows(&model)
+	paginatedRows := getAvailableRows(&model)
 
 	assert.Len(t, paginatedRows, numRows)
 	assert.Equal(t, 1, model.MaxPages())
@@ -72,7 +72,7 @@ func TestPaginationEmptyTableReturnsNoRows(t *testing.T) {
 
 	model := genPaginationTable(numRows, pageSize)
 
-	paginatedRows := getVisibleRows(&model)
+	paginatedRows := getAvailableRows(&model)
 
 	assert.Len(t, paginatedRows, numRows)
 }
@@ -82,7 +82,7 @@ func TestPaginationDefaultsToAllRows(t *testing.T) {
 
 	model := genPaginationTable(numRows, 0)
 
-	paginatedRows := getVisibleRows(&model)
+	paginatedRows := getAvailableRows(&model)
 
 	assert.Len(t, paginatedRows, numRows)
 }
@@ -95,7 +95,7 @@ func TestPaginationReturnsPartialFirstPage(t *testing.T) {
 
 	model := genPaginationTable(numRows, pageSize)
 
-	paginatedRows := getVisibleRows(&model)
+	paginatedRows := getAvailableRows(&model)
 
 	assert.Len(t, paginatedRows, numRows)
 }
@@ -108,7 +108,7 @@ func TestPaginationReturnsFirstFullPage(t *testing.T) {
 
 	model := genPaginationTable(numRows, pageSize)
 
-	paginatedRows := getVisibleRows(&model)
+	paginatedRows := getAvailableRows(&model)
 
 	assert.Len(t, paginatedRows, pageSize)
 
@@ -127,7 +127,7 @@ func TestPaginationReturnsSecondFullPageAfterMoving(t *testing.T) {
 
 	model.pageDown()
 
-	paginatedRows := getVisibleRows(&model)
+	paginatedRows := getAvailableRows(&model)
 
 	assert.Len(t, paginatedRows, pageSize)
 
@@ -146,7 +146,7 @@ func TestPaginationReturnsPartialFinalPage(t *testing.T) {
 
 	model.pageDown()
 
-	paginatedRows := getVisibleRows(&model)
+	paginatedRows := getAvailableRows(&model)
 
 	assert.Len(t, paginatedRows, numRows-pageSize)
 
@@ -165,7 +165,7 @@ func TestPaginationWrapsUpPartial(t *testing.T) {
 
 	model.pageUp()
 
-	paginatedRows := getVisibleRows(&model)
+	paginatedRows := getAvailableRows(&model)
 
 	assert.Len(t, paginatedRows, numRows-pageSize)
 
@@ -184,7 +184,7 @@ func TestPaginationWrapsUpFull(t *testing.T) {
 
 	model.pageUp()
 
-	paginatedRows := getVisibleRows(&model)
+	paginatedRows := getAvailableRows(&model)
 
 	assert.Len(t, paginatedRows, numRows-pageSize)
 
@@ -203,7 +203,7 @@ func TestPaginationWrapsUpSelf(t *testing.T) {
 
 	model.pageUp()
 
-	paginatedRows := getVisibleRows(&model)
+	paginatedRows := getAvailableRows(&model)
 
 	assert.Len(t, paginatedRows, numRows)
 
@@ -223,7 +223,7 @@ func TestPaginationWrapsDown(t *testing.T) {
 	model.pageDown()
 	model.pageDown()
 
-	paginatedRows := getVisibleRows(&model)
+	paginatedRows := getAvailableRows(&model)
 
 	assert.Len(t, paginatedRows, pageSize)
 
@@ -243,7 +243,7 @@ func TestPaginationWrapsDownSelf(t *testing.T) {
 	model.pageDown()
 	model.pageDown()
 
-	paginatedRows := getVisibleRows(&model)
+	paginatedRows := getAvailableRows(&model)
 
 	assert.Len(t, paginatedRows, pageSize)
 

--- a/table/row.go
+++ b/table/row.go
@@ -44,7 +44,7 @@ func (r Row) WithStyle(style lipgloss.Style) Row {
 // nolint: cyclop
 func (m Model) renderRow(rowIndex int, last bool) string {
 	numColumns := len(m.columns)
-	row := m.GetVisibleRows()[rowIndex]
+	row := m.GetAvailableRows()[rowIndex]
 	highlighted := rowIndex == m.rowCursorIndex
 
 	columnStrings := []string{}

--- a/table/sort_test.go
+++ b/table/sort_test.go
@@ -24,7 +24,7 @@ func TestSortSingleColumnAscAndDesc(t *testing.T) {
 
 	assertOrder := func(expectedList []string) {
 		for index, expected := range expectedList {
-			idVal, ok := model.GetVisibleRows()[index].Data[idColKey]
+			idVal, ok := model.GetAvailableRows()[index].Data[idColKey]
 
 			if expected != "" {
 				assert.True(t, ok)
@@ -47,7 +47,7 @@ func TestSortSingleColumnAscAndDesc(t *testing.T) {
 		}
 	}
 
-	assert.Len(t, model.GetVisibleRows(), len(rows))
+	assert.Len(t, model.GetAvailableRows(), len(rows))
 	assertOrder([]string{"", "a", "b", "c"})
 
 	model = model.SortByDesc(idColKey)
@@ -70,7 +70,7 @@ func TestSortSingleColumnIntsAsc(t *testing.T) {
 
 	assertOrder := func(expectedList []int) {
 		for index, expected := range expectedList {
-			idVal, ok := model.GetVisibleRows()[index].Data[idColKey]
+			idVal, ok := model.GetAvailableRows()[index].Data[idColKey]
 
 			assert.True(t, ok)
 
@@ -87,7 +87,7 @@ func TestSortSingleColumnIntsAsc(t *testing.T) {
 		}
 	}
 
-	assert.Len(t, model.GetVisibleRows(), len(rows))
+	assert.Len(t, model.GetAvailableRows(), len(rows))
 	assertOrder([]int{1, 2, 13})
 }
 
@@ -115,17 +115,17 @@ func TestSortTwoColumnsAscDescMix(t *testing.T) {
 	}).SortByAsc(nameKey).ThenSortByDesc(scoreKey)
 
 	assertVals := func(index int, name string, score int) {
-		actualName, ok := model.GetVisibleRows()[index].Data[nameKey].(string)
+		actualName, ok := model.GetAvailableRows()[index].Data[nameKey].(string)
 		assert.True(t, ok)
 
-		actualScore, ok := model.GetVisibleRows()[index].Data[scoreKey].(int)
+		actualScore, ok := model.GetAvailableRows()[index].Data[scoreKey].(int)
 		assert.True(t, ok)
 
 		assert.Equal(t, name, actualName)
 		assert.Equal(t, score, actualScore)
 	}
 
-	assert.Len(t, model.GetVisibleRows(), 4)
+	assert.Len(t, model.GetAvailableRows(), 4)
 
 	assertVals(0, "a", 100)
 	assertVals(1, "a", 75)

--- a/table/update.go
+++ b/table/update.go
@@ -9,7 +9,7 @@ func (m *Model) moveHighlightUp() {
 	m.rowCursorIndex--
 
 	if m.rowCursorIndex < 0 {
-		m.rowCursorIndex = len(m.GetVisibleRows()) - 1
+		m.rowCursorIndex = len(m.GetAvailableRows()) - 1
 	}
 
 	m.currentPage = m.expectedPageForRowIndex(m.rowCursorIndex)
@@ -18,7 +18,7 @@ func (m *Model) moveHighlightUp() {
 func (m *Model) moveHighlightDown() {
 	m.rowCursorIndex++
 
-	if m.rowCursorIndex >= len(m.GetVisibleRows()) {
+	if m.rowCursorIndex >= len(m.GetAvailableRows()) {
 		m.rowCursorIndex = 0
 	}
 
@@ -26,12 +26,12 @@ func (m *Model) moveHighlightDown() {
 }
 
 func (m *Model) toggleSelect() {
-	if !m.selectableRows || len(m.GetVisibleRows()) == 0 {
+	if !m.selectableRows || len(m.GetAvailableRows()) == 0 {
 		return
 	}
 
-	rows := make([]Row, len(m.GetVisibleRows()))
-	copy(rows, m.GetVisibleRows())
+	rows := make([]Row, len(m.GetAvailableRows()))
+	copy(rows, m.GetAvailableRows())
 
 	rows[m.rowCursorIndex].selected = !rows[m.rowCursorIndex].selected
 
@@ -39,7 +39,7 @@ func (m *Model) toggleSelect() {
 
 	m.selectedRows = []Row{}
 
-	for _, row := range m.GetVisibleRows() {
+	for _, row := range m.GetAvailableRows() {
 		if row.selected {
 			m.selectedRows = append(m.selectedRows, row)
 		}

--- a/table/update_test.go
+++ b/table/update_test.go
@@ -229,11 +229,11 @@ func TestSelectingRowWhenTableUnselectableDoesNothing(t *testing.T) {
 		}),
 	}).Focused(true)
 
-	assert.False(t, model.GetVisibleRows()[0].selected, "Row shouldn't be selected to start")
+	assert.False(t, model.GetAvailableRows()[0].selected, "Row shouldn't be selected to start")
 
 	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 
-	assert.False(t, model.GetVisibleRows()[0].selected, "Row shouldn't be selected after key press")
+	assert.False(t, model.GetAvailableRows()[0].selected, "Row shouldn't be selected after key press")
 }
 
 func TestSelectingRowToggles(t *testing.T) {
@@ -256,20 +256,20 @@ func TestSelectingRowToggles(t *testing.T) {
 	keyEnter := tea.KeyMsg{Type: tea.KeyEnter}
 	keyDown := tea.KeyMsg{Type: tea.KeyDown}
 
-	assert.False(t, model.GetVisibleRows()[0].selected, "Row shouldn't be selected to start")
+	assert.False(t, model.GetAvailableRows()[0].selected, "Row shouldn't be selected to start")
 	assert.Len(t, model.SelectedRows(), 0)
 
 	model, _ = model.Update(keyEnter)
-	assert.True(t, model.GetVisibleRows()[0].selected, "Row should be selected after first toggle")
+	assert.True(t, model.GetAvailableRows()[0].selected, "Row should be selected after first toggle")
 	assert.Len(t, model.SelectedRows(), 1)
 
 	model, _ = model.Update(keyEnter)
-	assert.False(t, model.GetVisibleRows()[0].selected, "Row should not be selected after second toggle")
+	assert.False(t, model.GetAvailableRows()[0].selected, "Row should not be selected after second toggle")
 	assert.Len(t, model.SelectedRows(), 0)
 
 	model, _ = model.Update(keyDown)
 	model, _ = model.Update(keyEnter)
-	assert.True(t, model.GetVisibleRows()[1].selected, "Second row should be selected after moving and toggling")
+	assert.True(t, model.GetAvailableRows()[1].selected, "Second row should be selected after moving and toggling")
 }
 
 func TestFilterWithKeypresses(t *testing.T) {
@@ -297,30 +297,30 @@ func TestFilterWithKeypresses(t *testing.T) {
 		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyEscape})
 	}
 
-	visible := model.GetVisibleRows()
+	availableRows := model.GetAvailableRows()
 
-	assert.Len(t, visible, 2)
+	assert.Len(t, availableRows, 2)
 	hitKey(rune(model.KeyMap().Filter.Keys()[0][0]))
-	assert.Len(t, visible, 2)
+	assert.Len(t, availableRows, 2)
 	hitKey('p')
 	hitKey('i')
 	hitKey('k')
 
-	visible = model.GetVisibleRows()
+	availableRows = model.GetAvailableRows()
 
-	assert.Len(t, visible, 1)
+	assert.Len(t, availableRows, 1)
 
 	hitEnter()
 
 	hitKey('x')
 
-	visible = model.GetVisibleRows()
+	availableRows = model.GetAvailableRows()
 
-	assert.Len(t, visible, 1)
+	assert.Len(t, availableRows, 1)
 
 	hitEscape()
 
-	visible = model.GetVisibleRows()
+	availableRows = model.GetAvailableRows()
 
-	assert.Len(t, visible, 2)
+	assert.Len(t, availableRows, 2)
 }

--- a/table/view.go
+++ b/table/view.go
@@ -41,7 +41,7 @@ func (m Model) View() string {
 
 	rowStrs := []string{headerBlock}
 
-	startRowIndex, endRowIndex := m.VisibleIndices()
+	startRowIndex, endRowIndex := m.AvailableIndices()
 	for i := startRowIndex; i <= endRowIndex; i++ {
 		rowStrs = append(rowStrs, m.renderRow(i, i == endRowIndex))
 	}


### PR DESCRIPTION
Rename visible to available to avoid ambiguity as to whether visible is visible on the UI or available on the data.

API changes are backward compatible.