### PR TITLE
enable filter works with table api(not in the footer)

### DIFF
--- a/examples/filterapi/main.go
+++ b/examples/filterapi/main.go
@@ -31,7 +31,7 @@ func NewModel() Model {
 			New(columns).
 			Filtered(true).
 			Focused(true).
-			WithNoFooter().
+			WithFooterVisibility(false).
 			WithPageSize(10).
 			WithRows([]table.Row{
 				table.NewRow(table.RowData{
@@ -69,33 +69,34 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds []tea.Cmd
 	)
 
-	cmds = append(cmds, cmd)
-
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		// global
-		if msg.String() == "ctrl+c" || msg.String() == "q" {
+		if msg.String() == "ctrl+c" {
 			cmds = append(cmds, tea.Quit)
 			return m, tea.Batch(cmds...)
-		} else {
-			// event to filter
-			if m.filterTextInput.Focused() {
-				if msg.String() == "enter" {
-					m.filterTextInput.Blur()
-				} else {
-					m.filterTextInput, cmd = m.filterTextInput.Update(msg)
-				}
-				m.table = m.table.WithFilterInput(m.filterTextInput)
-				return m, tea.Batch(cmds...)
+		}
+		// event to filter
+		if m.filterTextInput.Focused() {
+			if msg.String() == "enter" {
+				m.filterTextInput.Blur()
+			} else {
+				m.filterTextInput, cmd = m.filterTextInput.Update(msg)
 			}
+			m.table = m.table.WithFilterInput(m.filterTextInput)
+			return m, tea.Batch(cmds...)
+		}
 
-			// others component
-			switch msg.String() {
-			case "/":
-				m.filterTextInput.Focus()
-			default:
-				m.table, cmd = m.table.Update(msg)
-			}
+		// others component
+		switch msg.String() {
+		case "/":
+			m.filterTextInput.Focus()
+		case "q":
+			cmds = append(cmds, tea.Quit)
+			return m, tea.Batch(cmds...)
+		default:
+			m.table, cmd = m.table.Update(msg)
+			cmds = append(cmds, cmd)
 		}
 
 	}

--- a/examples/filterapi/main.go
+++ b/examples/filterapi/main.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+	"log"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/evertras/bubble-table/table"
+)
+
+const (
+	columnKeyTitle       = "title"
+	columnKeyAuthor      = "author"
+	columnKeyDescription = "description"
+)
+
+type Model struct {
+	table           table.Model
+	filterTextInput textinput.Model
+}
+
+func NewModel() Model {
+	columns := []table.Column{
+		table.NewColumn(columnKeyTitle, "Title", 13).WithFiltered(true),
+		table.NewColumn(columnKeyAuthor, "Author", 13).WithFiltered(true),
+		table.NewColumn(columnKeyDescription, "Description", 50),
+	}
+	return Model{
+		table: table.
+			New(columns).
+			Filtered(true).
+			Focused(true).
+			WithNoFooter().
+			WithPageSize(10).
+			WithRows([]table.Row{
+				table.NewRow(table.RowData{
+					columnKeyTitle:       "Computer Systems : A Programmer's Perspective",
+					columnKeyAuthor:      "Randal E. Bryant、David R. O'Hallaron / Prentice Hall ",
+					columnKeyDescription: "This book explains the important and enduring concepts underlying all computer...",
+				}),
+				table.NewRow(table.RowData{
+					columnKeyTitle:       "Effective Java : 3rd Edition",
+					columnKeyAuthor:      "Joshua Bloch",
+					columnKeyDescription: "The Definitive Guide to Java Platform Best Practices—Updated for Java 9 Java ...",
+				}),
+				table.NewRow(table.RowData{
+					columnKeyTitle:       "Structure and Interpretation of Computer Programs - 2nd Edition (MIT)",
+					columnKeyAuthor:      "Harold Abelson、Gerald Jay Sussman",
+					columnKeyDescription: "Structure and Interpretation of Computer Programs has had a dramatic impact on...",
+				}),
+				table.NewRow(table.RowData{
+					columnKeyTitle:       "Game Programming Patterns",
+					columnKeyAuthor:      "Robert Nystrom / Genever Benning",
+					columnKeyDescription: "The biggest challenge facing many game programmers is completing their game. M...",
+				}),
+			}),
+		filterTextInput: textinput.New(),
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var (
+		cmd  tea.Cmd
+		cmds []tea.Cmd
+	)
+
+	cmds = append(cmds, cmd)
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		// global
+		if msg.String() == "ctrl+c" || msg.String() == "q" {
+			cmds = append(cmds, tea.Quit)
+			return m, tea.Batch(cmds...)
+		} else {
+			// event to filter
+			if m.filterTextInput.Focused() {
+				if msg.String() == "enter" {
+					m.filterTextInput.Blur()
+				} else {
+					m.filterTextInput, cmd = m.filterTextInput.Update(msg)
+				}
+				m.table = m.table.WithFilterInput(m.filterTextInput)
+				return m, tea.Batch(cmds...)
+			}
+
+			// others component
+			switch msg.String() {
+			case "/":
+				m.filterTextInput.Focus()
+			default:
+				m.table, cmd = m.table.Update(msg)
+			}
+		}
+
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
+func (m Model) View() string {
+	body := strings.Builder{}
+
+	body.WriteString("A filtered simple default table\n" +
+		"Currently filter by Title and Author, press / + letters to start filtering, and escape to clear filter.\nPress q or ctrl+c to quit\n\n")
+
+	body.WriteString(m.filterTextInput.View() + "\n")
+	body.WriteString(m.table.View())
+
+	return body.String()
+}
+
+func main() {
+	p := tea.NewProgram(NewModel())
+
+	if err := p.Start(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 )
@@ -178,4 +179,28 @@ func TestGetFilteredRowsRefocusAfterFilter(t *testing.T) {
 	assert.Equal(t, 1, model.CurrentPage())
 	assert.Equal(t, 1, model.MaxPages())
 	assert.Equal(t, 0, model.TotalRows())
+}
+
+func TestFitlerWithOthersTextInput(t *testing.T) {
+	columns := []Column{NewColumn("title", "title", 10).WithFiltered(true)}
+	rows := []Row{
+		NewRow(RowData{
+			"title":       "AAA",
+			"description": "",
+		}),
+		NewRow(RowData{
+			"title":       "BBB",
+			"description": "",
+		}),
+		// Empty
+		NewRow(RowData{}),
+	}
+	model := New(columns).WithRows(rows).Filtered(true)
+	input := textinput.New()
+	input.SetValue("AaA")
+	model = model.WithFilterInput(input)
+
+	filteredRows := model.getFilteredRows(rows)
+
+	assert.Len(t, filteredRows, 1)
 }

--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -181,7 +181,7 @@ func TestGetFilteredRowsRefocusAfterFilter(t *testing.T) {
 	assert.Equal(t, 0, model.TotalRows())
 }
 
-func TestFitlerWithOthersTextInput(t *testing.T) {
+func TestFilterWithExternalTextInput(t *testing.T) {
 	columns := []Column{NewColumn("title", "title", 10).WithFiltered(true)}
 	rows := []Row{
 		NewRow(RowData{

--- a/table/footer.go
+++ b/table/footer.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (m Model) hasFooter() bool {
-	return m.isRenderFooter && (m.staticFooter != "" || m.pageSize != 0 || m.filtered)
+	return m.footerVisible && (m.staticFooter != "" || m.pageSize != 0 || m.filtered)
 }
 
 func (m Model) renderFooter() string {

--- a/table/footer.go
+++ b/table/footer.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (m Model) hasFooter() bool {
-	return m.staticFooter != "" || m.pageSize != 0 || m.filtered
+	return m.isRenderFooter && (m.staticFooter != "" || m.pageSize != 0 || m.filtered)
 }
 
 func (m Model) renderFooter() string {
@@ -25,7 +25,7 @@ func (m Model) renderFooter() string {
 	sections := []string{}
 
 	if m.filtered && (m.filterTextInput.Focused() || m.filterTextInput.Value() != "") {
-		sections = append(sections, fmt.Sprintf("/%s", m.filterTextInput.View()))
+		sections = append(sections, m.filterTextInput.View())
 	}
 
 	// paged feature enabled

--- a/table/model.go
+++ b/table/model.go
@@ -36,8 +36,8 @@ type Model struct {
 	unselectedText string
 
 	// Footers
-	isRenderFooter bool
-	staticFooter   string
+	footerVisible bool
+	staticFooter  string
 
 	// Pagination
 	pageSize    int
@@ -66,7 +66,7 @@ func New(columns []Column) Model {
 		columns:        make([]Column, len(columns)),
 		highlightStyle: defaultHighlightStyle.Copy(),
 		border:         borderDefault,
-		isRenderFooter: true,
+		footerVisible:  true,
 		keyMap:         DefaultKeyMap(),
 
 		selectedText:   "[x]",

--- a/table/model.go
+++ b/table/model.go
@@ -36,7 +36,8 @@ type Model struct {
 	unselectedText string
 
 	// Footers
-	staticFooter string
+	isRenderFooter bool
+	staticFooter   string
 
 	// Pagination
 	pageSize    int
@@ -60,11 +61,12 @@ type Model struct {
 // New creates a new table ready for further modifications.
 func New(columns []Column) Model {
 	filterInput := textinput.New()
-	filterInput.Prompt = ""
+	filterInput.Prompt = "/"
 	model := Model{
 		columns:        make([]Column, len(columns)),
 		highlightStyle: defaultHighlightStyle.Copy(),
 		border:         borderDefault,
+		isRenderFooter: true,
 		keyMap:         DefaultKeyMap(),
 
 		selectedText:   "[x]",

--- a/table/options.go
+++ b/table/options.go
@@ -258,16 +258,9 @@ func (m Model) WithFilterInput(input textinput.Model) Model {
 	return m
 }
 
-// WithNoFooter disables the footer.
-func (m Model) WithNoFooter() Model {
-	m.isRenderFooter = false
-
-	return m
-}
-
-// WithFooter enable the footer for the table.
-func (m Model) WithFooter() Model {
-	m.isRenderFooter = true
+// WithFooterVisibility set the visibility of footer.
+func (m Model) WithFooterVisibility(visibility bool) Model {
+	m.footerVisible = visibility
 
 	return m
 }

--- a/table/options.go
+++ b/table/options.go
@@ -251,7 +251,9 @@ func (m Model) WithColumns(columns []Column) Model {
 	return m
 }
 
-// WithFilterInput sets the filter input for the table.  This can be used as API of filter input.
+// WithFilterInput makes the table use the provided text input bubble for
+// filtering rather than using the built-in default.  This allows for external
+// text input controls to be used.
 func (m Model) WithFilterInput(input textinput.Model) Model {
 	m.filterTextInput = input
 

--- a/table/options.go
+++ b/table/options.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -246,6 +247,27 @@ func (m Model) WithColumns(columns []Column) Model {
 	copy(m.columns, columns)
 
 	m.recalculateWidth()
+
+	return m
+}
+
+// WithFilterInput sets the filter input for the table.  This can be used as API of filter input.
+func (m Model) WithFilterInput(input textinput.Model) Model {
+	m.filterTextInput = input
+
+	return m
+}
+
+// WithNoFooter disables the footer.
+func (m Model) WithNoFooter() Model {
+	m.isRenderFooter = false
+
+	return m
+}
+
+// WithFooter enable the footer for the table.
+func (m Model) WithFooter() Model {
+	m.isRenderFooter = true
 
 	return m
 }

--- a/table/options.go
+++ b/table/options.go
@@ -260,7 +260,7 @@ func (m Model) WithFilterInput(input textinput.Model) Model {
 	return m
 }
 
-// WithFooterVisibility set the visibility of footer.
+// WithFooterVisibility sets the visibility of the footer.
 func (m Model) WithFooterVisibility(visibility bool) Model {
 	m.footerVisible = visibility
 

--- a/table/options_test.go
+++ b/table/options_test.go
@@ -129,4 +129,11 @@ func TestPageOptions(t *testing.T) {
 	model = model.WithCurrentPage(6)
 	assert.Equal(t, 6, model.CurrentPage())
 	assert.Equal(t, 26, model.rowCursorIndex)
+
+	model = model.WithNoFooter()
+	assert.Equal(t, "", model.renderFooter())
+
+	model = model.WithFooter()
+	assert.Greater(t, len(model.renderFooter()), 10)
+	assert.Contains(t, model.renderFooter(), "6/6")
 }

--- a/table/options_test.go
+++ b/table/options_test.go
@@ -130,10 +130,10 @@ func TestPageOptions(t *testing.T) {
 	assert.Equal(t, 6, model.CurrentPage())
 	assert.Equal(t, 26, model.rowCursorIndex)
 
-	model = model.WithNoFooter()
+	model = model.WithFooterVisibility(false)
 	assert.Equal(t, "", model.renderFooter())
 
-	model = model.WithFooter()
+	model = model.WithFooterVisibility(true)
 	assert.Greater(t, len(model.renderFooter()), 10)
 	assert.Contains(t, model.renderFooter(), "6/6")
 }


### PR DESCRIPTION
We already have keyword filtering, but this can only be displayed in the footer of the form. If I want a form without a footer, or if I want to have the ability to manually control the filtering feature, I need an API to connect to the form to manipulate it.


Before:

```
A filtered simple default table
Currently filter by Title and Author, press / + letters to start filtering, and escape to clear filter.
Press q or ctrl+c to quit

┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃        Title┃       Author┃                                       Description┃
┣━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
┃Computer Sys…┃Randal E. Br…┃This book explains the important and enduring con…┃
┃Structure an…┃Harold Abels…┃Structure and Interpretation of Computer Programs…┃
┣━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
┃                                                                     /com  1/1┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
```

New sytle:

```
A filtered simple default table
Currently filter by Title and Author, press / + letters to start filtering, and escape to clear filter.
Press q or ctrl+c to quit

> com 
┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃        Title┃       Author┃                                       Description┃
┣━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
┃Computer Sys…┃Randal E. Br…┃This book explains the important and enduring con…┃
┃Structure an…┃Harold Abels…┃Structure and Interpretation of Computer Programs…┃
┗━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

```
```