### PR TITLE
Fix bug: previously selected rows aren't cleared up after calling `WithRows`

### DIFF
--- a/table/options.go
+++ b/table/options.go
@@ -32,6 +32,7 @@ func (m Model) HeaderStyle(style lipgloss.Style) Model {
 // WithRows sets the rows to show as data in the table.
 func (m Model) WithRows(rows []Row) Model {
 	m.rows = rows
+	m.selectedRows = nil
 
 	if m.pageSize != 0 {
 		maxPage := m.MaxPages()


### PR DESCRIPTION
The app that I'm building has an initial screen where you can select different "providers" for things, and then for each provider it will jump to another screen where it shows a list of items in a table. The table gets created once, and then every time a provider is selected the contents get refreshed doing something like this:

```go
m.table = m.table.WithRows(rows)
```

That has been working pretty well, however, I've found that if I had previously selected rows, when changing the displayed rows the selection isn't cleared up.

You can reproduce it by applying this diff to `examples/features/main.go`:

```patch
 examples/features/main.go | 9 +++++++++
 1 file changed, 9 insertions(+)

diff --git a/examples/features/main.go b/examples/features/main.go
index cecfc74..42bb411 100644
--- a/examples/features/main.go
+++ b/examples/features/main.go
@@ -156,6 +156,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c", "esc", "q":
 			cmds = append(cmds, tea.Quit)
+		case "x":
+			m.tableModel = m.tableModel.WithRows([]table.Row{
+				table.NewRow(table.RowData{
+					columnKeyID:          "xyz",
+					columnKeyName:        "Good bye",
+					columnKeyDescription: "If you press enter again it will show the previously selected rows, unless you toggle selection on this one.",
+					columnKeyCount:       9,
+				}),
+			})
 		}
 	}
 
```

In some cases it's even panicking, as you can see in the following demo:
![evertras-bubble-table-bug](https://user-images.githubusercontent.com/108421/170051989-aef4f68b-4f6f-43b9-9046-240f11910c78.gif)
