### PR TITLE
Better docs for metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,48 @@ rows := []table.Row{
 }
 ```
 
+### A note on 'metadata'
+
+There may be cases where you wish to reference some kind of data object in the
+table.  For example, a table of users may display a user name, ID, etc., and you
+may wish to retrieve data about the user when the row is selected.  This can be
+accomplished by attaching hidden 'metadata' to the row in the same way as any
+other data.
+
+```golang
+const (
+  columnKeyID = "id"
+  columnKeyName = "名前"
+  columnKeyUserData = "userstuff"
+)
+
+// Notice there is no "userstuff" column, so it won't be displayed
+columns := []table.Column{
+  table.NewColumn(columnKeyID, "ID", 5),
+  table.NewColumn(columnKeyName, "Name", 10),
+}
+
+// Just one user for this quick snippet, check the example for more
+user := &SomeUser{
+  ID:   3,
+  Name: "Evertras",
+}
+
+rows := []table.Row{
+  // This row contains both an ID and a name
+  table.NewRow(table.RowData{
+    columnKeyID:       user.ID,
+    columnKeyName:     user.Name,
+
+    // This isn't displayed, but it remains attached to the row
+    columnKeyUserData: user,
+  }),
+}
+```
+
+For a more detailed demonstration of this idea in action, please see the
+[metadata example](./examples/metadata/main.go).
+
 ## Demos
 
 Code examples are located in [the examples directory](./examples).  Run commands

--- a/table/row.go
+++ b/table/row.go
@@ -6,7 +6,11 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// RowData is a map of string column keys to interface{} data.
+// RowData is a map of string column keys to interface{} data.  Data with a key
+// that matches a column key will be displayed.  Data with a key that does not
+// match a column key will not be displayed, but will remain attached to the Row.
+// This can be useful for attaching hidden metadata for future reference when
+// retrieving rows.
 type RowData map[string]interface{}
 
 // Row represents a row in the table with some data keyed to the table columns>


### PR DESCRIPTION
The ability to attach metadata existed, and an example was recently added, but it was difficult to find.  So we should add some more obvious hooks from both the readme and to the data struct itself for docs purposes.

Should finish off #74 for now.