### PR TITLE
Add visual examples and readmes for all examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ example-features:
 example-filter:
 	@go run ./examples/filter/*.go
 
+.PHONY: example-filterapi
+example-filterapi:
+	@go run ./examples/filterapi/*.go
+
 .PHONY: example-flex
 example-flex:
 	@go run ./examples/flex/*.go

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A customizable, interactive table component for the
 
 ![Styled table](https://user-images.githubusercontent.com/5923958/156778142-cc1a32e1-1b1e-4a65-b699-187f39f0f946.png)
 
-[View above sample source code](./examples/pokemon/main.go)
+[View above sample source code](./examples/pokemon)
 
 ## Contributing
 
@@ -20,12 +20,12 @@ for a few helpful tips!
 
 ## Features
 
-For a code reference of most available features, please see the [full feature example](./examples/features/main.go).
-If you want to get started with a simple default table, [check the simplest example](./examples/simplest/main.go).
+For a code reference of most available features, please see the [full feature example](./examples/features).
+If you want to get started with a simple default table, [check the simplest example](./examples/simplest).
 
 Displays a table with a header, rows, footer, and borders.
 
-Columns can be fixed-width [or flexible width](./examples/flex/main.go).
+Columns can be fixed-width [or flexible width](./examples/flex).
 
 Border shape is customizable with a basic thick square default.  The color can
 be modified by applying a base style with `lipgloss.NewStyle().BorderForeground(...)`.
@@ -33,7 +33,7 @@ be modified by applying a base style with `lipgloss.NewStyle().BorderForeground(
 Styles can be applied globally and to columns, rows, and individual cells.
 The base style is applied first, then column, then row, then cell when
 determining overrides.  The default base style is a basic right-alignment.
-[See the main feature example](./examples/features/main.go) to see styles and
+[See the main feature example](./examples/features) to see styles and
 how they override each other.
 
 Can be focused to highlight a row and navigate with up/down (and j/k).  These
@@ -50,7 +50,7 @@ a text box in the footer and `/` (customizable by keybind) to start filtering.
 Columns can be sorted in either ascending or descending order.  Multiple columns
 can be specified in a row.  If multiple columns are specified, first the table
 is sorted by the first specified column, then each group within that column is
-sorted in smaller and smaller groups.  [See the sorting example](examples/sorting/main.go)
+sorted in smaller and smaller groups.  [See the sorting example](examples/sorting)
 for more information.  If a column contains numbers (either ints or floats),
 the numbers will be sorted by numeric value.  Otherwise rendered string values
 will be compared.
@@ -72,7 +72,7 @@ If it does not exist, nothing is rendered.
 Extra data in the `RowData` object is ignored.  This can be helpful to simply
 dump data into `RowData` and create columns that select what is interesting to
 view, or to generate different columns based on view options on the fly (see the
-[metadata example](./examples/metadata/main.go) for an example of using this).
+[metadata example](./examples/metadata) for an example of using this).
 
 An example is given below.  For more detailed examples, see
 [the examples directory](./examples).
@@ -170,13 +170,15 @@ rows := []table.Row{
 ```
 
 For a more detailed demonstration of this idea in action, please see the
-[metadata example](./examples/metadata/main.go).
+[metadata example](./examples/metadata).
 
 ## Demos
 
 Code examples are located in [the examples directory](./examples).  Run commands
 are added to the [Makefile](Makefile) for convenience but they should be as
-simple as `go run ./examples/features/main.go`, etc.
+simple as `go run ./examples/features/main.go`, etc.  You can also view what
+they look like by checking the example's directory in each README here on
+Github.
 
 To run the examples, clone this repo and run:
 

--- a/examples/dimensions/README.md
+++ b/examples/dimensions/README.md
@@ -1,0 +1,5 @@
+# Dimensions
+
+Shows some simple tables with various dimensions.
+
+<img width="534" alt="image" src="https://user-images.githubusercontent.com/5923958/170801679-92f420d7-5cdc-4c66-8d32-e421b1f5dc18.png">

--- a/examples/features/README.md
+++ b/examples/features/README.md
@@ -1,0 +1,8 @@
+# Full feature example
+
+This table contains most of the implemented features, but as more features have
+been added some have not made it into this demo for practical purposes.  This
+can be a useful reference for various features even if it's not a very
+appealing final product.
+
+<img width="593" alt="image" src="https://user-images.githubusercontent.com/5923958/170802611-84d15b28-0c57-4095-a321-d6ba05af58f8.png">

--- a/examples/filter/README.md
+++ b/examples/filter/README.md
@@ -1,0 +1,5 @@
+# Filter example
+
+Shows how the table can use a built-in filter to filter results.
+
+<img width="1052" alt="image" src="https://user-images.githubusercontent.com/5923958/170801744-a6488a8b-54f7-4132-b2c3-0e0d7166d902.png">

--- a/examples/filterapi/README.md
+++ b/examples/filterapi/README.md
@@ -1,0 +1,7 @@
+# Filter API example
+
+Similar to the [regular filter example](../filter/), but uses an external text
+box control for filtering.  This demonstrates how you can use your own text
+controls to perform filtering for more flexible UIs.
+
+<img width="1052" alt="image" src="https://user-images.githubusercontent.com/5923958/170801860-9bfac90e-00aa-4591-8799-00f67836e6b8.png">

--- a/examples/flex/README.md
+++ b/examples/flex/README.md
@@ -1,0 +1,6 @@
+# Flex example
+
+This example shows how to use flexible-width columns.  The example stretches to
+fill the full width of the terminal whenever it's resized.
+
+<img width="904" alt="image" src="https://user-images.githubusercontent.com/5923958/170801927-36599e10-7d25-4b8f-94d1-7052c25f572d.png">

--- a/examples/metadata/README.md
+++ b/examples/metadata/README.md
@@ -1,0 +1,7 @@
+# Metadata example
+
+This is the [pokemon example](../pokemon) with metadata attached to the rows in
+order to retrieve data, instead of retrieving the data directly from the row.
+This can be a useful technique to make more natural data transformations.
+
+<img width="1162" alt="image" src="https://user-images.githubusercontent.com/5923958/170801991-d5020bcf-4ef3-4798-8101-392ddfb347c7.png">

--- a/examples/pagination/README.md
+++ b/examples/pagination/README.md
@@ -1,0 +1,7 @@
+# Pagination example
+
+This example shows how to paginate data that would be too long to show in a
+single screen.  It also shows how to do this with multiple tables and to
+navigate between them.
+
+<img width="1131" alt="image" src="https://user-images.githubusercontent.com/5923958/170802030-6adcc324-7ee0-42c8-ac80-df1b0eb7d08b.png">

--- a/examples/pokemon/README.md
+++ b/examples/pokemon/README.md
@@ -1,0 +1,6 @@
+# Pokemon example
+
+This example is a general use of the table using various features to nicely
+display a table of Pokemon and some interesting statistics about them.
+
+<img width="1165" alt="image" src="https://user-images.githubusercontent.com/5923958/170802114-c9cdd209-ea72-4eff-878c-6c582aa82994.png">

--- a/examples/simplest/README.md
+++ b/examples/simplest/README.md
@@ -1,0 +1,7 @@
+# Simplest example
+
+This is a bare bones example of how to get started with the table component.  It
+uses all the defaults to simply present data, and is a good starting point for
+other use cases.
+
+<img width="462" alt="image" src="https://user-images.githubusercontent.com/5923958/170802181-f0c54b8b-625a-4ff0-8ffa-0e36cc2567eb.png">

--- a/examples/sorting/README.md
+++ b/examples/sorting/README.md
@@ -1,0 +1,8 @@
+# Sorting example
+
+This example shows how to use the sorting feature, which sorts columns.  It
+demonstrates how numbers are numerically sorted while strings are alphabetically
+sorted.  It also demonstrates multi-column sorting to group different kinds of
+data together and sort within them.
+
+<img width="461" alt="image" src="https://user-images.githubusercontent.com/5923958/170802272-d3cbbf44-69f5-4e18-a672-1dcb360de9b2.png">

--- a/examples/updates/README.md
+++ b/examples/updates/README.md
@@ -1,0 +1,5 @@
+# Update example
+
+Shows how to update data in the table from an external API returning data.
+
+![table-gif](https://user-images.githubusercontent.com/5923958/170802479-a4395407-f286-42d6-9165-0580db6030db.gif)


### PR DESCRIPTION
Adds readmes/screenshots/gifs to all examples, and updates the main README to point to the READMEs of the examples rather than directly to the code.

Closes #78 