### PR TITLE
Feature: select rows programatically

### DIFF
--- a/table/model.go
+++ b/table/model.go
@@ -24,7 +24,6 @@ type Model struct {
 	focused        bool
 	keyMap         KeyMap
 	selectableRows bool
-	selectedRows   []Row
 	rowCursorIndex int
 
 	// Styles

--- a/table/options.go
+++ b/table/options.go
@@ -32,7 +32,6 @@ func (m Model) HeaderStyle(style lipgloss.Style) Model {
 // WithRows sets the rows to show as data in the table.
 func (m Model) WithRows(rows []Row) Model {
 	m.rows = rows
-	m.selectedRows = nil
 
 	if m.pageSize != 0 {
 		maxPage := m.MaxPages()
@@ -93,15 +92,15 @@ func (m Model) HighlightedRow() Row {
 // SelectedRows returns all rows that have been set as selected by the user.
 func (m Model) SelectedRows() []Row {
 	rows := m.GetVisibleRows()
-	m.selectedRows = make([]Row, 0, len(rows))
+	selectedRows := make([]Row, 0, len(rows))
 
 	for _, row := range rows {
 		if row.selected {
-			m.selectedRows = append(m.selectedRows, row)
+			selectedRows = append(selectedRows, row)
 		}
 	}
 
-	return m.selectedRows
+	return selectedRows
 }
 
 // HighlightStyle sets a custom style to use when the row is being highlighted

--- a/table/options.go
+++ b/table/options.go
@@ -92,6 +92,14 @@ func (m Model) HighlightedRow() Row {
 
 // SelectedRows returns all rows that have been set as selected by the user.
 func (m Model) SelectedRows() []Row {
+	m.selectedRows = []Row{}
+
+	for _, row := range m.GetVisibleRows() {
+		if row.selected {
+			m.selectedRows = append(m.selectedRows, row)
+		}
+	}
+
 	return m.selectedRows
 }
 

--- a/table/options.go
+++ b/table/options.go
@@ -92,9 +92,10 @@ func (m Model) HighlightedRow() Row {
 
 // SelectedRows returns all rows that have been set as selected by the user.
 func (m Model) SelectedRows() []Row {
-	m.selectedRows = []Row{}
+	rows := m.GetVisibleRows()
+	m.selectedRows = make([]Row, 0, len(rows))
 
-	for _, row := range m.GetVisibleRows() {
+	for _, row := range rows {
 		if row.selected {
 			m.selectedRows = append(m.selectedRows, row)
 		}

--- a/table/options.go
+++ b/table/options.go
@@ -91,10 +91,9 @@ func (m Model) HighlightedRow() Row {
 
 // SelectedRows returns all rows that have been set as selected by the user.
 func (m Model) SelectedRows() []Row {
-	rows := m.GetVisibleRows()
-	selectedRows := make([]Row, 0, len(rows))
+	selectedRows := []Row{}
 
-	for _, row := range rows {
+	for _, row := range m.GetVisibleRows() {
 		if row.selected {
 			selectedRows = append(selectedRows, row)
 		}

--- a/table/options_test.go
+++ b/table/options_test.go
@@ -140,31 +140,45 @@ func TestPageOptions(t *testing.T) {
 
 func TestSelectRowsProgramatically(t *testing.T) {
 	const col = "id"
-	newRow := func(id int, selected bool) Row {
-		return NewRow(RowData{col: id}).Selected(selected)
-	}
 
 	tests := map[string]struct {
-		rows, selected []Row
+		rows        []Row
+		selectedIds []int
 	}{
 		"no rows selected": {
-			[]Row{newRow(1, false), newRow(2, false), newRow(2, false)},
-			[]Row{},
+			[]Row{
+				NewRow(RowData{col: 1}),
+				NewRow(RowData{col: 2}),
+				NewRow(RowData{col: 3}),
+			},
+			[]int{},
 		},
 
 		"all rows selected": {
-			[]Row{newRow(1, true), newRow(2, true), newRow(3, true)},
-			[]Row{newRow(1, true), newRow(2, true), newRow(3, true)},
+			[]Row{
+				NewRow(RowData{col: 1}).Selected(true),
+				NewRow(RowData{col: 2}).Selected(true),
+				NewRow(RowData{col: 3}).Selected(true),
+			},
+			[]int{1, 2, 3},
 		},
 
 		"first row selected": {
-			[]Row{newRow(1, true), newRow(2, false), newRow(3, false)},
-			[]Row{newRow(1, true)},
+			[]Row{
+				NewRow(RowData{col: 1}).Selected(true),
+				NewRow(RowData{col: 2}),
+				NewRow(RowData{col: 3}),
+			},
+			[]int{1},
 		},
 
 		"last row selected": {
-			[]Row{newRow(1, false), newRow(2, false), newRow(3, true)},
-			[]Row{newRow(3, true)},
+			[]Row{
+				NewRow(RowData{col: 1}),
+				NewRow(RowData{col: 2}),
+				NewRow(RowData{col: 3}).Selected(true),
+			},
+			[]int{3},
 		},
 	}
 
@@ -176,7 +190,10 @@ func TestSelectRowsProgramatically(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			sel := model.WithRows(tt.rows).SelectedRows()
 
-			assert.Equal(t, tt.selected, sel)
+			assert.Equal(t, len(tt.selectedIds), len(sel))
+			for i, id := range tt.selectedIds {
+				assert.Equal(t, id, sel[i].Data[col], "expecting row %d to have same %s column value", i)
+			}
 		})
 	}
 }

--- a/table/options_test.go
+++ b/table/options_test.go
@@ -137,3 +137,46 @@ func TestPageOptions(t *testing.T) {
 	assert.Greater(t, len(model.renderFooter()), 10)
 	assert.Contains(t, model.renderFooter(), "6/6")
 }
+
+func TestSelectRowsProgramatically(t *testing.T) {
+	const col = "id"
+	newRow := func(id int, selected bool) Row {
+		return NewRow(RowData{col: id}).Selected(selected)
+	}
+
+	tests := map[string]struct {
+		rows, selected []Row
+	}{
+		"no rows selected": {
+			[]Row{newRow(1, false), newRow(2, false), newRow(2, false)},
+			[]Row{},
+		},
+
+		"all rows selected": {
+			[]Row{newRow(1, true), newRow(2, true), newRow(3, true)},
+			[]Row{newRow(1, true), newRow(2, true), newRow(3, true)},
+		},
+
+		"first row selected": {
+			[]Row{newRow(1, true), newRow(2, false), newRow(3, false)},
+			[]Row{newRow(1, true)},
+		},
+
+		"last row selected": {
+			[]Row{newRow(1, false), newRow(2, false), newRow(3, true)},
+			[]Row{newRow(3, true)},
+		},
+	}
+
+	model := New([]Column{
+		NewColumn(col, col, 1),
+	})
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			sel := model.WithRows(tt.rows).SelectedRows()
+
+			assert.Equal(t, tt.selected, sel)
+		})
+	}
+}

--- a/table/options_test.go
+++ b/table/options_test.go
@@ -180,3 +180,30 @@ func TestSelectRowsProgramatically(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkSelectedRows(b *testing.B) {
+	const N = 1000
+
+	b.ReportAllocs()
+
+	rows := make([]Row, 0, N)
+	for i := 0; i < N; i++ {
+		rows = append(rows, NewRow(RowData{"row": i}).Selected(i%2 == 0))
+	}
+
+	model := New([]Column{
+		NewColumn("row", "Row", 4),
+	}).WithRows(rows)
+
+	var sel []Row
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sel = model.SelectedRows()
+	}
+
+	Rows = sel
+}
+
+var Rows []Row

--- a/table/row.go
+++ b/table/row.go
@@ -106,7 +106,7 @@ func (m Model) renderRow(rowIndex int, last bool) string {
 	return lipgloss.JoinHorizontal(lipgloss.Bottom, columnStrings...)
 }
 
-// Selected allows to indicate if the row should be selected or not.
+// Selected sets whether the row is selected or not.
 func (r Row) Selected(selected bool) Row {
 	r.selected = selected
 	return r

--- a/table/row.go
+++ b/table/row.go
@@ -105,3 +105,9 @@ func (m Model) renderRow(rowIndex int, last bool) string {
 
 	return lipgloss.JoinHorizontal(lipgloss.Bottom, columnStrings...)
 }
+
+// Selected allows to indicate if the row should be selected or not.
+func (r Row) Selected(selected bool) Row {
+	r.selected = selected
+	return r
+}

--- a/table/row.go
+++ b/table/row.go
@@ -109,5 +109,6 @@ func (m Model) renderRow(rowIndex int, last bool) string {
 // Selected sets whether the row is selected or not.
 func (r Row) Selected(selected bool) Row {
 	r.selected = selected
+
 	return r
 }

--- a/table/update.go
+++ b/table/update.go
@@ -36,14 +36,6 @@ func (m *Model) toggleSelect() {
 	rows[m.rowCursorIndex].selected = !rows[m.rowCursorIndex].selected
 
 	m.rows = rows
-
-	m.selectedRows = []Row{}
-
-	for _, row := range m.GetVisibleRows() {
-		if row.selected {
-			m.selectedRows = append(m.selectedRows, row)
-		}
-	}
 }
 
 func (m Model) updateFilterTextInput(msg tea.Msg) (Model, tea.Cmd) {


### PR DESCRIPTION
Add a new `Row.Selected(bool) Row` function that allows to indicate if the row is selected or not in a programatic manner. In addition to this it:

* refactors the way `Model.SelectedRows() []Row` works by computing the selected rows whenever this method is called instead of when the mark is toggled;
* adds test for selecting rows programatically;
* adds benchmark for `Model.SelectedRows()`
* reduce some allocations in `Model.SelectedRows`

As a byproduct of these changes, the previously reported and fixed bug #80 won't reappear again.