### PR TITLE
Extra sort test coverage and remove lingering dead test code

### DIFF
--- a/table/sort_test.go
+++ b/table/sort_test.go
@@ -10,8 +10,11 @@ import (
 func TestSortSingleColumnAscAndDesc(t *testing.T) {
 	const idColKey = "id"
 
+	// Check mixing types
+	type someType string
+
 	rows := []Row{
-		NewRow(RowData{idColKey: "b"}),
+		NewRow(RowData{idColKey: someType("b")}),
 		NewRow(RowData{idColKey: NewStyledCell("c", lipgloss.NewStyle().Bold(true))}),
 		NewRow(RowData{idColKey: "a"}),
 		// Missing data
@@ -37,6 +40,9 @@ func TestSortSingleColumnAscAndDesc(t *testing.T) {
 			switch idVal := idVal.(type) {
 			case string:
 				assert.Equal(t, expected, idVal)
+
+			case someType:
+				assert.Equal(t, expected, string(idVal))
 
 			case StyledCell:
 				assert.Equal(t, expected, idVal.Data)

--- a/table/update_test.go
+++ b/table/update_test.go
@@ -33,10 +33,6 @@ func TestUnfocusedDoesntMove(t *testing.T) {
 	assert.True(t, ok, "Failed to convert to string")
 
 	assert.Equal(t, "first", id, "Should still be on first row")
-
-	model, _ = model.Update(tea.KeyMsg{
-		Type: tea.KeyHome,
-	})
 }
 
 func TestPageKeysDoNothingWhenNoPages(t *testing.T) {


### PR DESCRIPTION
Get `sort` to 100% coverage by ensuring we can mix data types as expected.