### PR TITLE
Missing data indicator

### DIFF
--- a/examples/features/main.go
+++ b/examples/features/main.go
@@ -59,8 +59,8 @@ func NewModel() Model {
 
 	rows := []table.Row{
 		table.NewRow(table.RowData{
-			columnKeyID:          "abc",
-			columnKeyName:        "Hello",
+			columnKeyID: "abc",
+			// Missing name
 			columnKeyDescription: "The first table entry, ever",
 			columnKeyCount:       4,
 		}),
@@ -114,7 +114,11 @@ func NewModel() Model {
 					Foreground(lipgloss.Color("#a7a")).
 					Align(lipgloss.Left),
 			).
-			SortByAsc(columnKeyID),
+			SortByAsc(columnKeyID).
+			WithMissingDataIndicatorStyled(table.StyledCell{
+				Style: lipgloss.NewStyle().Foreground(lipgloss.Color("#faa")),
+				Data:  "<ない>",
+			}),
 	}
 
 	model.updateFooter()

--- a/table/model.go
+++ b/table/model.go
@@ -20,6 +20,9 @@ type Model struct {
 	columns []Column
 	rows    []Row
 
+	// Shown when data is missing from a row
+	missingDataIndicator interface{}
+
 	// Interaction
 	focused        bool
 	keyMap         KeyMap

--- a/table/options.go
+++ b/table/options.go
@@ -318,3 +318,23 @@ func (m Model) ScrollLeft() Model {
 
 	return m
 }
+
+// WithMissingDataIndicator sets an indicator to use when data for a column is
+// not found in a given row.  Note that this is for completely missing data,
+// an empty string or other zero value that is explicitly set is not considered
+// to be missing.
+func (m Model) WithMissingDataIndicator(str string) Model {
+	m.missingDataIndicator = str
+
+	return m
+}
+
+// WithMissingDataIndicatorStyled sets a styled indicator to use when data for
+// a column is not found in a given row.  Note that this is for completely
+// missing data, an empty string or other zero value that is explicitly set is
+// not considered to be missing.
+func (m Model) WithMissingDataIndicatorStyled(styled StyledCell) Model {
+	m.missingDataIndicator = styled
+
+	return m
+}

--- a/table/row.go
+++ b/table/row.go
@@ -60,8 +60,18 @@ func (m Model) renderRowColumnData(row Row, column Column, rowStyle lipgloss.Sty
 		str = ">"
 	} else if column.key == columnKeyOverflowLeft {
 		str = "<"
-	} else if entry, exists := row.Data[column.key]; exists {
-		switch entry := entry.(type) {
+	} else {
+		var data interface{}
+
+		if entry, exists := row.Data[column.key]; exists {
+			data = entry
+		} else if m.missingDataIndicator != nil {
+			data = m.missingDataIndicator
+		} else {
+			data = ""
+		}
+
+		switch entry := data.(type) {
 		case StyledCell:
 			str = fmt.Sprintf("%v", entry.Data)
 			cellStyle = entry.Style.Copy().Inherit(cellStyle)

--- a/table/view_test.go
+++ b/table/view_test.go
@@ -452,16 +452,16 @@ func TestSimple3x3WithMissingIndicator(t *testing.T) {
 				continue
 			}
 
-			id := fmt.Sprintf("%d", columnIndex)
+			columnKey := fmt.Sprintf("%d", columnIndex)
 
 			if rowIndex == 2 && columnIndex == 3 {
 				// Empty string to ensure that zero value data is not 'missing'
-				rowData[id] = ""
+				rowData[columnKey] = ""
 
 				continue
 			}
 
-			rowData[id] = fmt.Sprintf("%d,%d", columnIndex, rowIndex)
+			rowData[columnKey] = fmt.Sprintf("%d,%d", columnIndex, rowIndex)
 		}
 
 		rows = append(rows, NewRow(rowData))

--- a/table/view_test.go
+++ b/table/view_test.go
@@ -454,6 +454,13 @@ func TestSimple3x3WithMissingIndicator(t *testing.T) {
 
 			id := fmt.Sprintf("%d", columnIndex)
 
+			if rowIndex == 2 && columnIndex == 3 {
+				// Empty string to ensure that zero value data is not 'missing'
+				rowData[id] = ""
+
+				continue
+			}
+
 			rowData[id] = fmt.Sprintf("%d,%d", columnIndex, rowIndex)
 		}
 
@@ -466,7 +473,7 @@ func TestSimple3x3WithMissingIndicator(t *testing.T) {
 ┃   1┃   2┃   3┃
 ┣━━━━╋━━━━╋━━━━┫
 ┃ 1,1┃ 2,1┃ 3,1┃
-┃ 1,2┃  XX┃ 3,2┃
+┃ 1,2┃  XX┃    ┃
 ┃ 1,3┃ 2,3┃ 3,3┃
 ┣━━━━┻━━━━┻━━━━┫
 ┃        Footer┃

--- a/table/view_test.go
+++ b/table/view_test.go
@@ -391,6 +391,138 @@ func TestSimple3x3WithFooterView(t *testing.T) {
 	assert.Equal(t, expectedTable, rendered)
 }
 
+func TestSimple3x3WithMissingData(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+		NewColumn("3", "3", 4),
+	})
+
+	rows := []Row{}
+
+	for rowIndex := 1; rowIndex <= 3; rowIndex++ {
+		rowData := RowData{}
+
+		for columnIndex := 1; columnIndex <= 3; columnIndex++ {
+			// Take out the center
+			if rowIndex == 2 && columnIndex == 2 {
+				continue
+			}
+
+			id := fmt.Sprintf("%d", columnIndex)
+
+			rowData[id] = fmt.Sprintf("%d,%d", columnIndex, rowIndex)
+		}
+
+		rows = append(rows, NewRow(rowData))
+	}
+
+	model = model.WithRows(rows).WithStaticFooter("Footer")
+
+	const expectedTable = `┏━━━━┳━━━━┳━━━━┓
+┃   1┃   2┃   3┃
+┣━━━━╋━━━━╋━━━━┫
+┃ 1,1┃ 2,1┃ 3,1┃
+┃ 1,2┃    ┃ 3,2┃
+┃ 1,3┃ 2,3┃ 3,3┃
+┣━━━━┻━━━━┻━━━━┫
+┃        Footer┃
+┗━━━━━━━━━━━━━━┛`
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
+func TestSimple3x3WithMissingIndicator(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+		NewColumn("3", "3", 4),
+	}).WithMissingDataIndicator("XX")
+
+	rows := []Row{}
+
+	for rowIndex := 1; rowIndex <= 3; rowIndex++ {
+		rowData := RowData{}
+
+		for columnIndex := 1; columnIndex <= 3; columnIndex++ {
+			// Take out the center
+			if rowIndex == 2 && columnIndex == 2 {
+				continue
+			}
+
+			id := fmt.Sprintf("%d", columnIndex)
+
+			rowData[id] = fmt.Sprintf("%d,%d", columnIndex, rowIndex)
+		}
+
+		rows = append(rows, NewRow(rowData))
+	}
+
+	model = model.WithRows(rows).WithStaticFooter("Footer")
+
+	const expectedTable = `┏━━━━┳━━━━┳━━━━┓
+┃   1┃   2┃   3┃
+┣━━━━╋━━━━╋━━━━┫
+┃ 1,1┃ 2,1┃ 3,1┃
+┃ 1,2┃  XX┃ 3,2┃
+┃ 1,3┃ 2,3┃ 3,3┃
+┣━━━━┻━━━━┻━━━━┫
+┃        Footer┃
+┗━━━━━━━━━━━━━━┛`
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
+func TestSimple3x3WithMissingIndicatorStyled(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+		NewColumn("3", "3", 4),
+	}).WithMissingDataIndicatorStyled(StyledCell{
+		Style: lipgloss.NewStyle().Align(lipgloss.Left),
+		Data:  "XX",
+	})
+
+	rows := []Row{}
+
+	for rowIndex := 1; rowIndex <= 3; rowIndex++ {
+		rowData := RowData{}
+
+		for columnIndex := 1; columnIndex <= 3; columnIndex++ {
+			// Take out the center
+			if rowIndex == 2 && columnIndex == 2 {
+				continue
+			}
+
+			id := fmt.Sprintf("%d", columnIndex)
+
+			rowData[id] = fmt.Sprintf("%d,%d", columnIndex, rowIndex)
+		}
+
+		rows = append(rows, NewRow(rowData))
+	}
+
+	model = model.WithRows(rows).WithStaticFooter("Footer")
+
+	const expectedTable = `┏━━━━┳━━━━┳━━━━┓
+┃   1┃   2┃   3┃
+┣━━━━╋━━━━╋━━━━┫
+┃ 1,1┃ 2,1┃ 3,1┃
+┃ 1,2┃XX  ┃ 3,2┃
+┃ 1,3┃ 2,3┃ 3,3┃
+┣━━━━┻━━━━┻━━━━┫
+┃        Footer┃
+┗━━━━━━━━━━━━━━┛`
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
 func TestPaged3x3WithNoSpecifiedFooter(t *testing.T) {
 	model := New([]Column{
 		NewColumn("1", "1", 4),


### PR DESCRIPTION
Adds an option to show a given indicator when data is not present in the row.  This distinguishes between zero value (such as `""` or `0`) and data that is simply not present in the row data.  Zero value data is shown as expected, but missing data will use the missing data indicator, if supplied.  Supports styled and regular strings.

Closes #102 

Related to #94 discussion