### PR TITLE
Perform all actions for keybinds, don't short-circuit

### DIFF
--- a/table/scrolling_test.go
+++ b/table/scrolling_test.go
@@ -357,8 +357,10 @@ func TestHorizontalScrollingStopEdgeCases(t *testing.T) {
 func TestHorizontalScrollingWithCustomKeybind(t *testing.T) {
 	keymap := DefaultKeyMap()
 
-	keymap.ScrollRight = key.NewBinding(key.WithKeys("x"))
-	keymap.ScrollLeft = key.NewBinding(key.WithKeys("y"))
+	// These intentionally overlap with the keybinds for paging, to ensure
+	// that conflicts can live together
+	keymap.ScrollRight = key.NewBinding(key.WithKeys("right"))
+	keymap.ScrollLeft = key.NewBinding(key.WithKeys("left"))
 
 	model := New([]Column{
 		NewColumn("1", "1", 4),
@@ -391,11 +393,11 @@ func TestHorizontalScrollingWithCustomKeybind(t *testing.T) {
 ┗━┻━━━━┻━━━━┻━━━━┛`
 
 	hitScrollRight := func() {
-		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRight})
 	}
 
 	hitScrollLeft := func() {
-		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyLeft})
 	}
 
 	assert.Equal(t, expectedTableOriginal, model.View())

--- a/table/update.go
+++ b/table/update.go
@@ -54,38 +54,47 @@ func (m Model) updateFilterTextInput(msg tea.Msg) (Model, tea.Cmd) {
 
 // nolint: cyclop // This is just a series of Matches tests
 func (m *Model) handleKeypress(msg tea.KeyMsg) {
-	switch {
-	case key.Matches(msg, m.keyMap.RowDown):
+	if key.Matches(msg, m.keyMap.RowDown) {
 		m.moveHighlightDown()
+	}
 
-	case key.Matches(msg, m.keyMap.RowUp):
+	if key.Matches(msg, m.keyMap.RowUp) {
 		m.moveHighlightUp()
+	}
 
-	case key.Matches(msg, m.keyMap.RowSelectToggle):
+	if key.Matches(msg, m.keyMap.RowSelectToggle) {
 		m.toggleSelect()
+	}
 
-	case key.Matches(msg, m.keyMap.PageDown):
+	if key.Matches(msg, m.keyMap.PageDown) {
 		m.pageDown()
+	}
 
-	case key.Matches(msg, m.keyMap.PageUp):
+	if key.Matches(msg, m.keyMap.PageUp) {
 		m.pageUp()
+	}
 
-	case key.Matches(msg, m.keyMap.PageFirst):
+	if key.Matches(msg, m.keyMap.PageFirst) {
 		m.pageFirst()
+	}
 
-	case key.Matches(msg, m.keyMap.PageLast):
+	if key.Matches(msg, m.keyMap.PageLast) {
 		m.pageLast()
+	}
 
-	case key.Matches(msg, m.keyMap.Filter):
+	if key.Matches(msg, m.keyMap.Filter) {
 		m.filterTextInput.Focus()
+	}
 
-	case key.Matches(msg, m.keyMap.FilterClear):
+	if key.Matches(msg, m.keyMap.FilterClear) {
 		m.filterTextInput.Reset()
+	}
 
-	case key.Matches(msg, m.keyMap.ScrollRight):
+	if key.Matches(msg, m.keyMap.ScrollRight) {
 		m.scrollRight()
+	}
 
-	case key.Matches(msg, m.keyMap.ScrollLeft):
+	if key.Matches(msg, m.keyMap.ScrollLeft) {
 		m.scrollLeft()
 	}
 }


### PR DESCRIPTION
Instead of short-circuiting on the first action found, try to perform any action that matches.  This solves confusing behavior such as scrolling with left/right arrows not working as expected due to the paging action eating the keystroke... even if the table doesn't have any pages!

Closes #104 