### PR TITLE
Fix edge case of empty table with row index of -1

### DIFF
--- a/table/events_test.go
+++ b/table/events_test.go
@@ -91,4 +91,9 @@ func TestUserEventHighlightedIndexChanged(t *testing.T) {
 	hitDown()
 	events = model.GetLastUpdateUserEvents()
 	assert.Len(t, events, 0, "There's no row to change to for single row table, event shouldn't exist")
+
+	model = model.WithRows([]Row{})
+	hitDown()
+	events = model.GetLastUpdateUserEvents()
+	assert.Len(t, events, 0, "There's no row to change to for an empty table, event shouldn't exist")
 }

--- a/table/options.go
+++ b/table/options.go
@@ -9,12 +9,12 @@ import (
 func (m Model) WithHighlightedRow(index int) Model {
 	m.rowCursorIndex = index
 
-	if m.rowCursorIndex < 0 {
-		m.rowCursorIndex = 0
-	}
-
 	if m.rowCursorIndex >= len(m.GetVisibleRows()) {
 		m.rowCursorIndex = len(m.GetVisibleRows()) - 1
+	}
+
+	if m.rowCursorIndex < 0 {
+		m.rowCursorIndex = 0
 	}
 
 	m.currentPage = m.expectedPageForRowIndex(m.rowCursorIndex)
@@ -35,6 +35,10 @@ func (m Model) WithRows(rows []Row) Model {
 
 	if m.rowCursorIndex >= len(m.rows) {
 		m.rowCursorIndex = len(m.rows) - 1
+	}
+
+	if m.rowCursorIndex < 0 {
+		m.rowCursorIndex = 0
 	}
 
 	if m.pageSize != 0 {


### PR DESCRIPTION
There was an edge case where the highlighted row index might be -1 for an empty table.