### PR TITLE
Allow setting filter value directly with string

### DIFF
--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -223,6 +223,11 @@ func TestFilterWithSetValue(t *testing.T) {
 	model = model.WithFilterInputValue("AaA")
 
 	filteredRows := model.getFilteredRows(rows)
+	assert.Len(t, filteredRows, 1)
 
+	// Make sure it holds true after an update
+	model, _ = model.Update(tea.KeyRight)
+
+	filteredRows = model.getFilteredRows(rows)
 	assert.Len(t, filteredRows, 1)
 }

--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -204,3 +204,25 @@ func TestFilterWithExternalTextInput(t *testing.T) {
 
 	assert.Len(t, filteredRows, 1)
 }
+
+func TestFilterWithSetValue(t *testing.T) {
+	columns := []Column{NewColumn("title", "title", 10).WithFiltered(true)}
+	rows := []Row{
+		NewRow(RowData{
+			"title":       "AAA",
+			"description": "",
+		}),
+		NewRow(RowData{
+			"title":       "BBB",
+			"description": "",
+		}),
+		// Empty
+		NewRow(RowData{}),
+	}
+	model := New(columns).WithRows(rows).Filtered(true)
+	model = model.WithFilterInputValue("AaA")
+
+	filteredRows := model.getFilteredRows(rows)
+
+	assert.Len(t, filteredRows, 1)
+}

--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -227,7 +227,11 @@ func TestFilterWithSetValue(t *testing.T) {
 
 	// Make sure it holds true after an update
 	model, _ = model.Update(tea.KeyRight)
-
 	filteredRows = model.getFilteredRows(rows)
 	assert.Len(t, filteredRows, 1)
+
+	// Remove filter
+	model = model.WithFilterInputValue("")
+	filteredRows = model.getFilteredRows(rows)
+	assert.Len(t, filteredRows, 3)
 }

--- a/table/options.go
+++ b/table/options.go
@@ -284,6 +284,15 @@ func (m Model) WithFilterInput(input textinput.Model) Model {
 	return m
 }
 
+// WithFilterInputValue sets the filter value to the given string, immediately
+// applying it as if the user had typed it in.  Useful for external filter inputs
+// that are not necessarily a text input.
+func (m Model) WithFilterInputValue(value string) Model {
+	m.filterTextInput.SetValue(value)
+
+	return m
+}
+
 // WithFooterVisibility sets the visibility of the footer.
 func (m Model) WithFooterVisibility(visibility bool) Model {
 	m.footerVisible = visibility


### PR DESCRIPTION
Exposes the `SetValue()` function of the filter text input so that filters can be set directly with strings.

Helps #116 