### PR TITLE
Remove errant cursor when setting filter input manually

### DIFF
--- a/table/options.go
+++ b/table/options.go
@@ -289,6 +289,7 @@ func (m Model) WithFilterInput(input textinput.Model) Model {
 // that are not necessarily a text input.
 func (m Model) WithFilterInputValue(value string) Model {
 	m.filterTextInput.SetValue(value)
+	m.filterTextInput.Blur()
 
 	return m
 }


### PR DESCRIPTION
When setting the filter input text value, this causes the cursor to appear.  The cursor should not appear.

Helps #116 