### PR TITLE
Fix styling of footer when using base style with filter input

### DIFF
--- a/table/footer.go
+++ b/table/footer.go
@@ -17,7 +17,6 @@ func (m Model) renderFooter(width int, includeTop bool) string {
 	const borderAdjustment = 2
 
 	styleFooter := m.baseStyle.Copy().Inherit(m.border.styleFooter).Width(width - borderAdjustment)
-	inlineStyle := m.baseStyle.Copy().Inline(true)
 
 	if includeTop {
 		styleFooter.BorderTop(true)
@@ -35,9 +34,15 @@ func (m Model) renderFooter(width int, includeTop bool) string {
 
 	// paged feature enabled
 	if m.pageSize != 0 {
-		// Need to apply inline style here in case of filter input cursor, because
-		// the input cursor resets the style after rendering
-		sections = append(sections, inlineStyle.Render(fmt.Sprintf("%d/%d", m.CurrentPage(), m.MaxPages())))
+		str := fmt.Sprintf("%d/%d", m.CurrentPage(), m.MaxPages())
+		if m.filtered && m.filterTextInput.Focused() {
+			// Need to apply inline style here in case of filter input cursor, because
+			// the input cursor resets the style after rendering.  Note that Inline(true)
+			// creates a copy, so it's safe to use here without mutating the underlying
+			// base style.
+			str = m.baseStyle.Inline(true).Render(str)
+		}
+		sections = append(sections, str)
 	}
 
 	footerText := strings.Join(sections, " ")

--- a/table/footer.go
+++ b/table/footer.go
@@ -17,6 +17,7 @@ func (m Model) renderFooter(width int, includeTop bool) string {
 	const borderAdjustment = 2
 
 	styleFooter := m.baseStyle.Copy().Inherit(m.border.styleFooter).Width(width - borderAdjustment)
+	inlineStyle := m.baseStyle.Copy().Inline(true)
 
 	if includeTop {
 		styleFooter.BorderTop(true)
@@ -34,7 +35,9 @@ func (m Model) renderFooter(width int, includeTop bool) string {
 
 	// paged feature enabled
 	if m.pageSize != 0 {
-		sections = append(sections, fmt.Sprintf("%d/%d", m.CurrentPage(), m.MaxPages()))
+		// Need to apply inline style here in case of filter input cursor, because
+		// the input cursor resets the style after rendering
+		sections = append(sections, inlineStyle.Render(fmt.Sprintf("%d/%d", m.CurrentPage(), m.MaxPages())))
 	}
 
 	footerText := strings.Join(sections, " ")


### PR DESCRIPTION
Re-applies an inline version of the base style when using the basic filter text input, which then correctly applies things such as color to the page text.

Fixes #119 