### PR TITLE
Add query for if filter input is currently focused

### DIFF
--- a/table/query.go
+++ b/table/query.go
@@ -25,6 +25,12 @@ func (m *Model) GetIsFilterActive() bool {
 	return m.filterTextInput.Value() != ""
 }
 
+// GetIsFilterInputFocused returns true if the table's built-in filter input is
+// currently focused.
+func (m *Model) GetIsFilterInputFocused() bool {
+	return m.filterTextInput.Focused()
+}
+
 // GetCurrentFilter returns the current filter text being applied, or an empty
 // string if none is applied.
 func (m *Model) GetCurrentFilter() string {

--- a/table/query_test.go
+++ b/table/query_test.go
@@ -180,3 +180,22 @@ func TestGetPaginationWrapping(t *testing.T) {
 
 	assert.False(t, model.GetPaginationWrapping(), "Pagination wrapping setting did not update after setting option")
 }
+
+func TestGetIsFilterInputFocused(t *testing.T) {
+	model := New([]Column{}).Filtered(true).Focused(true)
+
+	assert.False(t, model.GetIsFilterInputFocused(), "Text input shouldn't start focused")
+
+	model, _ = model.Update(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune{'/'},
+	})
+
+	assert.True(t, model.GetIsFilterInputFocused(), "Did not trigger text input")
+
+	model, _ = model.Update(tea.KeyMsg{
+		Type: tea.KeyEnter,
+	})
+
+	assert.False(t, model.GetIsFilterInputFocused(), "Should no longer be focused after hitting enter")
+}


### PR DESCRIPTION
Adds query for if the filter input is currently focused, indicating that the user is actively typing into the filter field.  Useful for other controls to know whether they should react to typing or not.

Helps #122 