### PR TITLE
Add events for filter input being focused/unfocused

### DIFF
--- a/table/events.go
+++ b/table/events.go
@@ -48,3 +48,13 @@ type UserEventRowSelectToggled struct {
 	RowIndex   int
 	IsSelected bool
 }
+
+// UserEventFilterInputFocused indicates that the user has focused the filter
+// text input, so that any other typing will type into the filter field.  Only
+// activates for the built-in filter text box.
+type UserEventFilterInputFocused struct{}
+
+// UserEventFilterInputUnfocused indicates that the user has unfocused the filter
+// text input, which means the user is done typing into the filter field.  Only
+// activates for the built-in filter text box.
+type UserEventFilterInputUnfocused struct{}

--- a/table/events_test.go
+++ b/table/events_test.go
@@ -172,3 +172,36 @@ func TestUserEventRowSelectToggled(t *testing.T) {
 	events = model.GetLastUpdateUserEvents()
 	assert.Len(t, events, 0, "There's no row to select for an empty table, event shouldn't exist")
 }
+
+func TestFilterFocusEvents(t *testing.T) {
+	model := New([]Column{}).Filtered(true).Focused(true)
+
+	events := model.GetLastUpdateUserEvents()
+
+	assert.Empty(t, events, "Unexpected events to start")
+
+	// Start filter
+	model, _ = model.Update(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune{'/'},
+	})
+	events = model.GetLastUpdateUserEvents()
+	assert.Len(t, events, 1, "Only expected one event")
+	switch events[0].(type) {
+	case UserEventFilterInputFocused:
+	default:
+		assert.FailNow(t, "Unexpected event type")
+	}
+
+	// Stop filter
+	model, _ = model.Update(tea.KeyMsg{
+		Type: tea.KeyEnter,
+	})
+	events = model.GetLastUpdateUserEvents()
+	assert.Len(t, events, 1, "Only expected one event")
+	switch events[0].(type) {
+	case UserEventFilterInputUnfocused:
+	default:
+		assert.FailNow(t, "Unexpected event type")
+	}
+}

--- a/table/update.go
+++ b/table/update.go
@@ -93,6 +93,7 @@ func (m *Model) handleKeypress(msg tea.KeyMsg) {
 
 	if key.Matches(msg, m.keyMap.Filter) {
 		m.filterTextInput.Focus()
+		m.appendUserEvent(UserEventFilterInputFocused{})
 	}
 
 	if key.Matches(msg, m.keyMap.FilterClear) {
@@ -124,7 +125,14 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	}
 
 	if m.filterTextInput.Focused() {
-		return m.updateFilterTextInput(msg)
+		var cmd tea.Cmd
+		m, cmd = m.updateFilterTextInput(msg)
+
+		if !m.filterTextInput.Focused() {
+			m.appendUserEvent(UserEventFilterInputUnfocused{})
+		}
+
+		return m, cmd
 	}
 
 	switch msg := msg.(type) {


### PR DESCRIPTION
Adds events for when the built-in filter text box is focused or unfocused, allowing the outer app to react to it if needed.

Helps #122 