### PR TITLE
Go to first page on filter API change, same as built-in filter

### DIFF
--- a/examples/filterapi/main.go
+++ b/examples/filterapi/main.go
@@ -32,7 +32,7 @@ func NewModel() Model {
 			Filtered(true).
 			Focused(true).
 			WithFooterVisibility(false).
-			WithPageSize(10).
+			WithPageSize(2).
 			WithRows([]table.Row{
 				table.NewRow(table.RowData{
 					columnKeyTitle:       "Computer Systems : A Programmer's Perspective",

--- a/examples/filterapi/main.go
+++ b/examples/filterapi/main.go
@@ -32,7 +32,7 @@ func NewModel() Model {
 			Filtered(true).
 			Focused(true).
 			WithFooterVisibility(false).
-			WithPageSize(2).
+			WithPageSize(10).
 			WithRows([]table.Row{
 				table.NewRow(table.RowData{
 					columnKeyTitle:       "Computer Systems : A Programmer's Perspective",

--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -242,10 +242,15 @@ func TestFilterWithExternalTextInput(t *testing.T) {
 		// Empty
 		NewRow(RowData{}),
 	}
-	model := New(columns).WithRows(rows).Filtered(true)
+
+	// Page size 1 to test scrolling back if input changes
+	model := New(columns).WithRows(rows).Filtered(true).WithPageSize(1)
+	model.pageDown()
+	assert.Equal(t, 2, model.CurrentPage(), "Should start on second page for test")
 	input := textinput.New()
 	input.SetValue("AaA")
 	model = model.WithFilterInput(input)
+	assert.Equal(t, 1, model.CurrentPage(), "Did not go back to first page")
 
 	filteredRows := model.getFilteredRows(rows)
 
@@ -266,8 +271,14 @@ func TestFilterWithSetValue(t *testing.T) {
 		// Empty
 		NewRow(RowData{}),
 	}
-	model := New(columns).WithRows(rows).Filtered(true)
+
+	// Page size 1 to make sure we scroll back correctly
+	model := New(columns).WithRows(rows).Filtered(true).WithPageSize(1)
+	model.pageDown()
+	assert.Equal(t, 2, model.CurrentPage(), "Should start on second page for test")
 	model = model.WithFilterInputValue("AaA")
+
+	assert.Equal(t, 1, model.CurrentPage(), "Did not go back to first page")
 
 	filteredRows := model.getFilteredRows(rows)
 	assert.Len(t, filteredRows, 1)

--- a/table/options.go
+++ b/table/options.go
@@ -279,6 +279,10 @@ func (m Model) WithColumns(columns []Column) Model {
 // filtering rather than using the built-in default.  This allows for external
 // text input controls to be used.
 func (m Model) WithFilterInput(input textinput.Model) Model {
+	if m.filterTextInput.Value() != input.Value() {
+		m.pageFirst()
+	}
+
 	m.filterTextInput = input
 
 	return m
@@ -288,6 +292,10 @@ func (m Model) WithFilterInput(input textinput.Model) Model {
 // applying it as if the user had typed it in.  Useful for external filter inputs
 // that are not necessarily a text input.
 func (m Model) WithFilterInputValue(value string) Model {
+	if m.filterTextInput.Value() != value {
+		m.pageFirst()
+	}
+
 	m.filterTextInput.SetValue(value)
 	m.filterTextInput.Blur()
 


### PR DESCRIPTION
#136 

We were going back to the first page when our built-in filter changed, but not when the provided filter APIs changed.  This makes the behavior consistent across all filtering options.