### PR TITLE
Improve filtered rendering performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Profiling outputs
+*.prof
+
 # Outputs of the go coverage tool, specifically when used with LiteIDE
 *.out
 *.coverage

--- a/table/filter.go
+++ b/table/filter.go
@@ -47,7 +47,7 @@ func isRowMatched(columns []Column, row Row, filter string) bool {
 			data = dataV.Data
 		}
 
-		target := ""
+		var target string
 		switch dataV := data.(type) {
 		case string:
 			target = dataV

--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -324,3 +324,54 @@ func BenchmarkFilteredScrolling(b *testing.B) {
 		hitKey('j')
 	}
 }
+
+func BenchmarkFilteredScrollingPaged(b *testing.B) {
+	// Scrolling through a filtered table with many rows should be quick
+	// https://github.com/Evertras/bubble-table/issues/135
+	const rowCount = 40000
+	columns := []Column{NewColumn("title", "title", 10).WithFiltered(true)}
+	rows := make([]Row, rowCount)
+
+	for i := 0; i < rowCount; i++ {
+		rows[i] = NewRow(RowData{
+			"title": fmt.Sprintf("%d", i),
+		})
+	}
+
+	model := New(columns).WithRows(rows).Filtered(true).WithPageSize(50)
+	model = model.WithFilterInputValue("1")
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		model, _ = model.Update(
+			tea.KeyMsg{
+				Type:  tea.KeyRunes,
+				Runes: []rune{'j'},
+			})
+	}
+}
+
+func BenchmarkFilteredRenders(b *testing.B) {
+	// Rendering a filtered table should be fast
+	// https://github.com/Evertras/bubble-table/issues/135
+	const rowCount = 40000
+	columns := []Column{NewColumn("title", "title", 10).WithFiltered(true)}
+	rows := make([]Row, rowCount)
+
+	for i := 0; i < rowCount; i++ {
+		rows[i] = NewRow(RowData{
+			"title": fmt.Sprintf("%d", i),
+		})
+	}
+
+	model := New(columns).WithRows(rows).Filtered(true).WithPageSize(50)
+	model = model.WithFilterInputValue("1")
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Don't care about result, just rendering
+		_ = model.View()
+	}
+}

--- a/table/model.go
+++ b/table/model.go
@@ -20,6 +20,10 @@ type Model struct {
 	columns []Column
 	rows    []Row
 
+	// Caches for optimizations
+	visibleRowCacheUpdated bool
+	visibleRowCache        []Row
+
 	// Shown when data is missing from a row
 	missingDataIndicator interface{}
 

--- a/table/options.go
+++ b/table/options.go
@@ -32,6 +32,7 @@ func (m Model) HeaderStyle(style lipgloss.Style) Model {
 // WithRows sets the rows to show as data in the table.
 func (m Model) WithRows(rows []Row) Model {
 	m.rows = rows
+	m.visibleRowCacheUpdated = false
 
 	if m.rowCursorIndex >= len(m.rows) {
 		m.rowCursorIndex = len(m.rows) - 1
@@ -129,6 +130,7 @@ func (m Model) Focused(focused bool) Model {
 // Filtered allows the table to show rows that match the filter.
 func (m Model) Filtered(filtered bool) Model {
 	m.filtered = filtered
+	m.visibleRowCacheUpdated = false
 
 	return m
 }
@@ -284,6 +286,7 @@ func (m Model) WithFilterInput(input textinput.Model) Model {
 	}
 
 	m.filterTextInput = input
+	m.visibleRowCacheUpdated = false
 
 	return m
 }
@@ -298,6 +301,7 @@ func (m Model) WithFilterInputValue(value string) Model {
 
 	m.filterTextInput.SetValue(value)
 	m.filterTextInput.Blur()
+	m.visibleRowCacheUpdated = false
 
 	return m
 }

--- a/table/query.go
+++ b/table/query.go
@@ -38,13 +38,20 @@ func (m *Model) GetCurrentFilter() string {
 }
 
 // GetVisibleRows returns sorted and filtered rows.
-func (m Model) GetVisibleRows() []Row {
+func (m *Model) GetVisibleRows() []Row {
+	if m.visibleRowCacheUpdated {
+		return m.visibleRowCache
+	}
+
 	rows := make([]Row, len(m.rows))
 	copy(rows, m.rows)
 	if m.filtered {
 		rows = m.getFilteredRows(rows)
 	}
 	rows = getSortedRows(m.sortOrder, rows)
+
+	m.visibleRowCache = rows
+	m.visibleRowCacheUpdated = true
 
 	return rows
 }

--- a/table/sort.go
+++ b/table/sort.go
@@ -34,6 +34,8 @@ func (m Model) SortByAsc(columnKey string) Model {
 		},
 	}
 
+	m.visibleRowCacheUpdated = false
+
 	return m
 }
 
@@ -49,6 +51,8 @@ func (m Model) SortByDesc(columnKey string) Model {
 		},
 	}
 
+	m.visibleRowCacheUpdated = false
+
 	return m
 }
 
@@ -62,6 +66,8 @@ func (m Model) ThenSortByAsc(columnKey string) Model {
 		},
 	}, m.sortOrder...)
 
+	m.visibleRowCacheUpdated = false
+
 	return m
 }
 
@@ -74,6 +80,8 @@ func (m Model) ThenSortByDesc(columnKey string) Model {
 			Direction: SortDirectionDesc,
 		},
 	}, m.sortOrder...)
+
+	m.visibleRowCacheUpdated = false
 
 	return m
 }

--- a/table/update.go
+++ b/table/update.go
@@ -38,6 +38,7 @@ func (m *Model) toggleSelect() {
 	rows[m.rowCursorIndex].selected = !currentSelectedState
 
 	m.rows = rows
+	m.visibleRowCacheUpdated = false
 
 	m.appendUserEvent(UserEventRowSelectToggled{
 		RowIndex:   m.rowCursorIndex,
@@ -55,6 +56,7 @@ func (m Model) updateFilterTextInput(msg tea.Msg) (Model, tea.Cmd) {
 	}
 	m.filterTextInput, cmd = m.filterTextInput.Update(msg)
 	m.pageFirst()
+	m.visibleRowCacheUpdated = false
 
 	return m, cmd
 }
@@ -125,6 +127,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	if !m.focused {
 		return m, nil
 	}
+
+	m.visibleRowCacheUpdated = false
 
 	if m.filterTextInput.Focused() {
 		var cmd tea.Cmd


### PR DESCRIPTION
`GetVisibleRows` is being called all over the place.  This function is doing a LOT of calculation for any large data set.  So instead we cache it, and internally invalidate the cache whenever it would change.  This is purely an internal change and seems to massively improve performance when tested.

Helps #135 