### PR TITLE
Add `Model.GetFooterVisibility` function

### DIFF
--- a/table/query.go
+++ b/table/query.go
@@ -80,6 +80,14 @@ func (m *Model) GetHeaderVisibility() bool {
 	return m.headerVisible
 }
 
+// GetFooterVisibility returns true if the footer has been set to
+// visible (default) or false if the footer has been set to hidden.
+// Note that even if the footer is visible it will only be rendered if
+// it has contents.
+func (m *Model) GetFooterVisibility() bool {
+	return m.footerVisible
+}
+
 // GetPaginationWrapping returns true if pagination wrapping is enabled, or false
 // if disabled.  If disabled, navigating through pages will stop at the first
 // and last pages.

--- a/table/query_test.go
+++ b/table/query_test.go
@@ -171,6 +171,16 @@ func TestGetHeaderVisibility(t *testing.T) {
 	assert.False(t, model.GetHeaderVisibility(), "Header was not set to hidden")
 }
 
+func TestGetFooterVisibility(t *testing.T) {
+	model := New([]Column{})
+
+	assert.True(t, model.GetFooterVisibility(), "Footer should be visible by default")
+
+	model = model.WithFooterVisibility(false)
+
+	assert.False(t, model.GetFooterVisibility(), "Footer was not set to hidden")
+}
+
 func TestGetPaginationWrapping(t *testing.T) {
 	model := New([]Column{})
 


### PR DESCRIPTION
This is analog to the `GetHeaderVisibility` function. Note that it only reports if the footer should be visible, but if it has no contents it won't be rendered.