### PR TITLE
Render missing data for columns with format string

### DIFF
--- a/table/row.go
+++ b/table/row.go
@@ -61,20 +61,20 @@ func (m Model) renderRowColumnData(row Row, column Column, rowStyle lipgloss.Sty
 	} else if column.key == columnKeyOverflowLeft {
 		str = "<"
 	} else {
+		fmtString := "%v"
+
 		var data interface{}
 
 		if entry, exists := row.Data[column.key]; exists {
 			data = entry
+
+			if column.fmtString != "" {
+				fmtString = column.fmtString
+			}
 		} else if m.missingDataIndicator != nil {
 			data = m.missingDataIndicator
 		} else {
 			data = ""
-		}
-
-		fmtString := "%v"
-
-		if column.fmtString != "" {
-			fmtString = column.fmtString
 		}
 
 		switch entry := data.(type) {

--- a/table/view_test.go
+++ b/table/view_test.go
@@ -434,6 +434,49 @@ func TestSimple3x3WithMissingData(t *testing.T) {
 	assert.Equal(t, expectedTable, rendered)
 }
 
+func TestFmtStringWithMissingData(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4).WithFormatString("%.1f"),
+		NewColumn("3", "3", 4),
+	})
+
+	rows := []Row{}
+
+	for rowIndex := 1; rowIndex <= 3; rowIndex++ {
+		rowData := RowData{}
+
+		for columnIndex := 1; columnIndex <= 3; columnIndex++ {
+			// Take out the center
+			if rowIndex == 2 && columnIndex == 2 {
+				continue
+			}
+
+			id := fmt.Sprintf("%d", columnIndex)
+
+			rowData[id] = float64(columnIndex) + float64(rowIndex)/10.0
+		}
+
+		rows = append(rows, NewRow(rowData))
+	}
+
+	model = model.WithRows(rows).WithStaticFooter("Footer")
+
+	const expectedTable = `┏━━━━┳━━━━┳━━━━┓
+┃   1┃   2┃   3┃
+┣━━━━╋━━━━╋━━━━┫
+┃ 1.1┃ 2.1┃ 3.1┃
+┃ 1.2┃    ┃ 3.2┃
+┃ 1.3┃ 2.3┃ 3.3┃
+┣━━━━┻━━━━┻━━━━┫
+┃        Footer┃
+┗━━━━━━━━━━━━━━┛`
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
 func TestSimple3x3WithMissingIndicator(t *testing.T) {
 	model := New([]Column{
 		NewColumn("1", "1", 4),
@@ -484,6 +527,49 @@ func TestSimple3x3WithMissingIndicator(t *testing.T) {
 	assert.Equal(t, expectedTable, rendered)
 }
 
+func TestFmtStringWithMissingIndicator(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4).WithFormatString("%.1f"),
+		NewColumn("3", "3", 4),
+	}).WithMissingDataIndicator("XX")
+
+	rows := []Row{}
+
+	for rowIndex := 1; rowIndex <= 3; rowIndex++ {
+		rowData := RowData{}
+
+		for columnIndex := 1; columnIndex <= 3; columnIndex++ {
+			// Take out the center
+			if rowIndex == 2 && columnIndex == 2 {
+				continue
+			}
+
+			id := fmt.Sprintf("%d", columnIndex)
+
+			rowData[id] = float64(columnIndex) + float64(rowIndex)/10.0
+		}
+
+		rows = append(rows, NewRow(rowData))
+	}
+
+	model = model.WithRows(rows).WithStaticFooter("Footer")
+
+	const expectedTable = `┏━━━━┳━━━━┳━━━━┓
+┃   1┃   2┃   3┃
+┣━━━━╋━━━━╋━━━━┫
+┃ 1.1┃ 2.1┃ 3.1┃
+┃ 1.2┃  XX┃ 3.2┃
+┃ 1.3┃ 2.3┃ 3.3┃
+┣━━━━┻━━━━┻━━━━┫
+┃        Footer┃
+┗━━━━━━━━━━━━━━┛`
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
 func TestSimple3x3WithMissingIndicatorStyled(t *testing.T) {
 	model := New([]Column{
 		NewColumn("1", "1", 4),
@@ -521,6 +607,52 @@ func TestSimple3x3WithMissingIndicatorStyled(t *testing.T) {
 ┃ 1,1┃ 2,1┃ 3,1┃
 ┃ 1,2┃XX  ┃ 3,2┃
 ┃ 1,3┃ 2,3┃ 3,3┃
+┣━━━━┻━━━━┻━━━━┫
+┃        Footer┃
+┗━━━━━━━━━━━━━━┛`
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
+func TestFmtStringWithMissingIndicatorStyled(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4).WithFormatString("%.1f"),
+		NewColumn("3", "3", 4),
+	}).WithMissingDataIndicatorStyled(StyledCell{
+		Style: lipgloss.NewStyle().Align(lipgloss.Left),
+		Data:  "XX",
+	})
+
+	rows := []Row{}
+
+	for rowIndex := 1; rowIndex <= 3; rowIndex++ {
+		rowData := RowData{}
+
+		for columnIndex := 1; columnIndex <= 3; columnIndex++ {
+			// Take out the center
+			if rowIndex == 2 && columnIndex == 2 {
+				continue
+			}
+
+			id := fmt.Sprintf("%d", columnIndex)
+
+			rowData[id] = float64(columnIndex) + float64(rowIndex)/10.0
+		}
+
+		rows = append(rows, NewRow(rowData))
+	}
+
+	model = model.WithRows(rows).WithStaticFooter("Footer")
+
+	const expectedTable = `┏━━━━┳━━━━┳━━━━┓
+┃   1┃   2┃   3┃
+┣━━━━╋━━━━╋━━━━┫
+┃ 1.1┃ 2.1┃ 3.1┃
+┃ 1.2┃XX  ┃ 3.2┃
+┃ 1.3┃ 2.3┃ 3.3┃
 ┣━━━━┻━━━━┻━━━━┫
 ┃        Footer┃
 ┗━━━━━━━━━━━━━━┛`


### PR DESCRIPTION
If a column has a format string, and a row is missing data in that column, an unexpected error is shown.

```go
table.New([]table.Column{
	table.NewColumn(columnKeyName, "Name", 13),
	table.NewColumn(columnKeyElement, "Element", 10),
	table.NewColumn(columnKeyHeight, "Height", 16).WithFormatString("%.2f m"),
}).WithRows([]table.Row{
	table.NewRow(table.RowData{
		columnKeyName:    "Pikachu",
		columnKeyElement: "Electric",
		// height is missing
	}),
	table.NewRow(table.RowData{
		columnKeyName:    "Charmander",
		columnKeyElement: "Fire",
		columnKeyHeight:  0.6,
	}),
})
```

```
┏━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
┃         Name┃   Element┃          Height┃
┣━━━━━━━━━━━━━╋━━━━━━━━━━╋━━━━━━━━━━━━━━━━┫
┃      Pikachu┃  Electric┃  %!f(string=) m┃
┃   Charmander┃      Fire┃          0.60 m┃
┗━━━━━━━━━━━━━┻━━━━━━━━━━┻━━━━━━━━━━━━━━━━┛
```

This PR fixes the bug by only setting the format string if data exists.