### PR TITLE
fix: column style respects paddings and margins

### DIFF
--- a/table/row.go
+++ b/table/row.go
@@ -46,7 +46,7 @@ func (r Row) WithStyle(style lipgloss.Style) Row {
 
 //nolint:nestif,cyclop // This has many ifs, but they're short
 func (m Model) renderRowColumnData(row Row, column Column, rowStyle lipgloss.Style, borderStyle lipgloss.Style) string {
-	cellStyle := rowStyle.Copy().Inherit(column.style).Inherit(m.baseStyle)
+	cellStyle := forceInheritStyles(rowStyle.Copy(), column.style, m.baseStyle)
 
 	var str string
 

--- a/table/styles.go
+++ b/table/styles.go
@@ -1,0 +1,18 @@
+package table
+
+import "github.com/charmbracelet/lipgloss"
+
+// forceInheritStyles merges the given styles into the base style, and then
+// applies the padding and margin from the last style in the list.
+// The Inherit() method skips padding and margin, so this is a workaround.
+func forceInheritStyles(base lipgloss.Style, styles ...lipgloss.Style) lipgloss.Style {
+	merged := base.Copy()
+
+	for _, style := range styles {
+		merged = merged.Inherit(style).
+			Padding(style.GetPadding()).
+			Margin(style.GetMargin())
+	}
+
+	return merged
+}


### PR DESCRIPTION
Address https://github.com/Evertras/bubble-table/issues/130

A little context (copied and pasted from the issue):

What I found so far is this line. `cellStyle` is built by coping `rowStyle`  and `inherit` a `column.style`

```
func (m Model) renderRowColumnData(row Row, column Column, rowStyle lipgloss.Style, borderStyle lipgloss.Style) string {
	cellStyle := rowStyle.Copy().Inherit(column.style).Inherit(m.baseStyle)
```

In its implementation in the lipgloss package, we can see that margins and padding properties are skipped

```

func (s Style) Inherit(i Style) Style {
	s.init()

	for k, v := range i.rules {
		switch k {
		case marginTopKey, marginRightKey, marginBottomKey, marginLeftKey:
			// Margins are not inherited
			continue
		case paddingTopKey, paddingRightKey, paddingBottomKey, paddingLeftKey:
			// Padding is not inherited
			continue
		case backgroundKey:
			s.rules[k] = v

			// The margins also inherit the background color
			if !s.isSet(marginBackgroundKey) && !i.isSet(marginBackgroundKey) {
				s.rules[marginBackgroundKey] = v
			}
		}

		if _, exists := s.rules[k]; exists {
			continue
		}
		s.rules[k] = v
	}
	return s
}
```

---

With that knowledge, I created a column with left padding
```
	columns := []table.Column{
		table.NewColumn(columnKeyName, "Name", 10).WithStyle(
			lipgloss.NewStyle().
				Foreground(lipgloss.Color("#88f")),
		),
		table.NewColumn(columnKeyCountry, "Country", 20).WithStyle(
			lipgloss.NewStyle().
				Foreground(lipgloss.Color("#f88")).
				PaddingLeft(5),
		),
		table.NewColumn(columnKeyCurrency, "Currency", 10),
```

and change the renderRowColumnData a little bit

``` 
func (m Model) renderRowColumnData(row Row, column Column, rowStyle lipgloss.Style, borderStyle lipgloss.Style) string {
	cellStyle := rowStyle.Copy().Inherit(column.style).Inherit(m.baseStyle)

	_, _, _, colPadLeft := column.style.GetPadding()
	if colPadLeft > 0 {
		cellStyle = cellStyle.PaddingLeft(colPadLeft)
	}
```

Which results in the desired state:
<img width="1264" alt="image" src="https://github.com/Evertras/bubble-table/assets/23465248/3d935075-359e-4b7f-a291-0f0270546c26">

---

What we can do is:
-  modify the Inherit method or create a custom one overriding all values from the incoming style - this will be impossible to make in a finite period since contributions to charm are hella slow (or they do not like me dunno)
- append that logic into renderRowColumnData (for paddings and margins)

---

Okay, it may be tricky because GetPadding and GetMargins return values or 0 if a property is not set. Creating a simple if statement as I did may result in a situation when a rowStyle sets padding to >0 value and the user wants to have a column with padding ==0 and it will not be overridden.

Without access lipgloss.Style.rules it may be hard to implement simply. We can cover the override margins/paddings with a next column flag but I do not if it is a best approach here

---

It came out that we *cannot* set paddings and margins in base style because it breaks the layout 

`PaddingRight(10)`
<img width="677" alt="image" src="https://github.com/Evertras/bubble-table/assets/23465248/763702e9-acca-4d0f-8943-54e963e4105e">

`MarginRight()`
<img width="677" alt="image" src="https://github.com/Evertras/bubble-table/assets/23465248/fa7e763e-cee4-4c03-99f5-9f560c9e7f72">

