### PR TITLE
Persist selected column when columns are regenerated.

### DIFF
--- a/table/options.go
+++ b/table/options.go
@@ -299,6 +299,11 @@ func (m Model) WithColumns(columns []Column) Model {
 
 	m.recalculateWidth()
 
+	if m.selectableRows {
+		// Re-add the selectable column
+		m = m.SelectableRows(true)
+	}
+
 	return m
 }
 

--- a/table/view_selectable_test.go
+++ b/table/view_selectable_test.go
@@ -121,3 +121,44 @@ func TestSimple3x3WithCustomSelectableTextAndFooter(t *testing.T) {
 
 	assert.Equal(t, expectedTable, rendered)
 }
+
+func TestRegeneratingColumnsKeepsSelectableText(t *testing.T) {
+	columns := []Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+		NewColumn("3", "3", 4),
+	}
+
+	model := New(columns)
+
+	rows := []Row{}
+
+	for rowIndex := 1; rowIndex <= 3; rowIndex++ {
+		rowData := RowData{}
+
+		for columnIndex := 1; columnIndex <= 3; columnIndex++ {
+			id := fmt.Sprintf("%d", columnIndex)
+
+			rowData[id] = fmt.Sprintf("%d,%d", columnIndex, rowIndex)
+		}
+
+		rows = append(rows, NewRow(rowData))
+	}
+
+	model = model.WithRows(rows).
+		SelectableRows(true).
+		WithSelectedText(" ", "✓").
+		WithColumns(columns)
+
+	const expectedTable = `┏━┳━━━━┳━━━━┳━━━━┓
+┃✓┃   1┃   2┃   3┃
+┣━╋━━━━╋━━━━╋━━━━┫
+┃ ┃ 1,1┃ 2,1┃ 3,1┃
+┃ ┃ 1,2┃ 2,2┃ 3,2┃
+┃ ┃ 1,3┃ 2,3┃ 3,3┃
+┗━┻━━━━┻━━━━┻━━━━┛`
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}


### PR DESCRIPTION
Fixes #163 

We were dropping the selected column when using `WithColumns`, so just make sure to add it back in when regenerating columns.