### PR TITLE
Fix bug where selecting a row while filtered would lose all other rows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Lint
-        run: make lint
+        run: |
+          go mod tidy
+          make lint
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.4
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Lint
-        run: |
-          go mod tidy
-          make lint
+        run: make lint
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      # For whatever reason, 1.21.9 blows up because it can't
+      # find 'max' in some go lib... pinning to 1.21.4 fixes this
       - name: Install Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.51.1
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Lint
+        run: make lint
 

--- a/examples/filter/main.go
+++ b/examples/filter/main.go
@@ -30,6 +30,7 @@ func NewModel() Model {
 			Filtered(true).
 			Focused(true).
 			WithPageSize(10).
+			SelectableRows(true).
 			WithRows([]table.Row{
 				table.NewRow(table.RowData{
 					columnKeyTitle:       "Computer Systems : A Programmer's Perspective",

--- a/table/row.go
+++ b/table/row.go
@@ -2,6 +2,7 @@ package table
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/wordwrap"
@@ -21,13 +22,21 @@ type Row struct {
 	Data  RowData
 
 	selected bool
+
+	// id is an internal unique ID to match rows after they're copied
+	id uint32
 }
+
+var lastRowID uint32 = 1
 
 // NewRow creates a new row and copies the given row data.
 func NewRow(data RowData) Row {
 	row := Row{
 		Data: make(map[string]interface{}),
+		id:   lastRowID,
 	}
+
+	atomic.AddUint32(&lastRowID, 1)
 
 	for key, val := range data {
 		// Doesn't deep copy val, but close enough for now...

--- a/table/update.go
+++ b/table/update.go
@@ -51,14 +51,6 @@ func (m *Model) toggleSelect() {
 	})
 }
 
-func (m *Model) getUnderlyingRowIndex() int {
-	if !m.filtered || m.filterTextInput.Value() == "" {
-		return m.rowCursorIndex
-	}
-
-	return 0
-}
-
 func (m Model) updateFilterTextInput(msg tea.Msg) (Model, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {

--- a/table/update.go
+++ b/table/update.go
@@ -30,8 +30,7 @@ func (m *Model) toggleSelect() {
 		return
 	}
 
-	rows := make([]Row, len(m.GetVisibleRows()))
-	copy(rows, m.GetVisibleRows())
+	rows := m.GetVisibleRows()
 
 	currentSelectedState := rows[m.rowCursorIndex].selected
 

--- a/table/update.go
+++ b/table/update.go
@@ -32,17 +32,31 @@ func (m *Model) toggleSelect() {
 
 	rows := m.GetVisibleRows()
 
-	currentSelectedState := rows[m.rowCursorIndex].selected
+	rowID := rows[m.rowCursorIndex].id
 
-	rows[m.rowCursorIndex].selected = !currentSelectedState
+	currentSelectedState := false
 
-	m.rows = rows
+	for i := range m.rows {
+		if m.rows[i].id == rowID {
+			currentSelectedState = m.rows[i].selected
+			m.rows[i].selected = !m.rows[i].selected
+		}
+	}
+
 	m.visibleRowCacheUpdated = false
 
 	m.appendUserEvent(UserEventRowSelectToggled{
 		RowIndex:   m.rowCursorIndex,
 		IsSelected: !currentSelectedState,
 	})
+}
+
+func (m *Model) getUnderlyingRowIndex() int {
+	if !m.filtered || m.filterTextInput.Value() == "" {
+		return m.rowCursorIndex
+	}
+
+	return 0
 }
 
 func (m Model) updateFilterTextInput(msg tea.Msg) (Model, tea.Cmd) {

--- a/table/update_test.go
+++ b/table/update_test.go
@@ -330,3 +330,78 @@ func TestFilterWithKeypresses(t *testing.T) {
 
 	assert.Len(t, visible, 2)
 }
+
+func TestSelectOnFilteredTableDoesntLoseRows(t *testing.T) {
+	// Issue: https://github.com/Evertras/bubble-table/issues/170
+	//
+	// Basically, if you filter a table and then select a row, then
+	// clear the filter, then all the other rows should still exist.
+
+	cols := []Column{
+		NewColumn("name", "Name", 10).WithFiltered(true),
+	}
+
+	model := New(cols).WithRows([]Row{
+		NewRow(RowData{"name": "Charmander"}),
+		NewRow(RowData{"name": "Pikachu"}),
+	}).Focused(true).Filtered(true).SelectableRows(true)
+
+	hitKey := func(key rune) {
+		model, _ = model.Update(tea.KeyMsg{
+			Type:  tea.KeyRunes,
+			Runes: []rune{key},
+		})
+	}
+
+	hitEnter := func() {
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	}
+
+	hitEscape := func() {
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	}
+
+	hitSpacebar := func() {
+		model, _ = model.Update(tea.KeyMsg{Type: tea.KeySpace})
+	}
+
+	// First, apply the filter
+	//
+	// Note that we try and filter for the second row, "Pikachu"
+	// so that we can better ensure everything is stably intact
+	visible := model.GetVisibleRows()
+
+	assert.Len(t, visible, 2)
+	hitKey(rune(model.KeyMap().Filter.Keys()[0][0]))
+	assert.Len(t, visible, 2)
+	hitKey('p')
+	hitKey('i')
+	hitKey('k')
+
+	visible = model.GetVisibleRows()
+
+	assert.Len(t, visible, 1)
+
+	hitEnter()
+
+	// Now apply the selection toggle
+	hitSpacebar()
+
+	visible = model.GetVisibleRows()
+	assert.Len(t, visible, 1)
+	assert.True(t, visible[0].selected)
+
+	// Now clear the filter and make sure everything is intact
+	hitEscape()
+
+	visible = model.GetVisibleRows()
+
+	assert.Len(t, visible, 2)
+
+	if t.Failed() {
+		return
+	}
+
+	assert.False(t, visible[0].selected)
+	assert.True(t, visible[1].selected)
+}

--- a/table/update_test.go
+++ b/table/update_test.go
@@ -331,6 +331,10 @@ func TestFilterWithKeypresses(t *testing.T) {
 	assert.Len(t, visible, 2)
 }
 
+// This is a long test with a lot of movement keys pressed, that's okay because
+// it's simply repetitive and tracking the same kind of state change many times
+//
+//nolint:funlen
 func TestSelectOnFilteredTableDoesntLoseRows(t *testing.T) {
 	// Issue: https://github.com/Evertras/bubble-table/issues/170
 	//


### PR DESCRIPTION
https://github.com/Evertras/bubble-table/issues/170

Before, we would copy all visible rows over with just the modified row having toggled its select.  However, when filtered, the visible rows did not include all the filtered-out rows, so they would be lost.

Now we keep an internal ID on all rows.  This may also be useful in the future, but it's particularly useful to allow us to find the selected row and toggle its selection directly in the underlying row structure.  This is also quicker and requires less copying, which is a bonus, despite being a simple linear search.