### PR TITLE
fix: Require at least go 1.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and test
     strategy:
       matrix:
-        go-version: [~1.13, ^1]
+        go-version: [~1.18, ^1]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -32,4 +32,3 @@ jobs:
 
       - name: Test
         run: go test -race ./table
-

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.17.6"
+          go-version: "1.18.10"
 
       - name: Check out code
         uses: actions/checkout@v4
@@ -35,4 +35,3 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=covprofile -service=github
-

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evertras/bubble-table
 
-go 1.17
+go 1.18
 
 require (
 	github.com/charmbracelet/bubbles v0.11.0


### PR DESCRIPTION
This PR aims to fix https://github.com/Evertras/bubble-table/issues/179 by raising the minimum supported version of go from 1.17 to 1.18.