### PR TITLE
feat: Add `WithFuzzyFilter` to enable fuzzy filter matching

### DIFF
--- a/table/filter.go
+++ b/table/filter.go
@@ -19,7 +19,7 @@ func (m Model) getFilteredRows(rows []Row) []Row {
 		if m.filterFunc != nil {
 			availableFilterFunc = m.filterFunc
 		} else {
-			availableFilterFunc = newContainsFilter
+			availableFilterFunc = filterFuncContains
 		}
 
 		if availableFilterFunc(m.columns, row, filterInputValue) {
@@ -30,7 +30,9 @@ func (m Model) getFilteredRows(rows []Row) []Row {
 	return filteredRows
 }
 
-func newContainsFilter(columns []Column, row Row, filter string) bool {
+// filterFuncContains returns a filterFunc that performs case-insensitive
+// "contains" matching over all filterable columns in a row.
+func filterFuncContains(columns []Column, row Row, filter string) bool {
 	if filter == "" {
 		return true
 	}
@@ -78,9 +80,9 @@ func newContainsFilter(columns []Column, row Row, filter string) bool {
 	return !checkedAny
 }
 
-// newFuzzyFilter returns a filterFunc that performs case-insensitive fuzzy
+// filterFuncFuzzy returns a filterFunc that performs case-insensitive fuzzy
 // matching (subsequence) over the concatenation of all filterable column values.
-func newFuzzyFilter(columns []Column, row Row, filter string) bool {
+func filterFuncFuzzy(columns []Column, row Row, filter string) bool {
 	filter = strings.TrimSpace(filter)
 	if filter == "" {
 		return true

--- a/table/filter.go
+++ b/table/filter.go
@@ -19,7 +19,7 @@ func (m Model) getFilteredRows(rows []Row) []Row {
 		if m.filterFunc != nil {
 			availableFilterFunc = m.filterFunc
 		} else {
-			availableFilterFunc = isRowMatched
+			availableFilterFunc = newContainsFilter
 		}
 
 		if availableFilterFunc(m.columns, row, filterInputValue) {
@@ -30,7 +30,7 @@ func (m Model) getFilteredRows(rows []Row) []Row {
 	return filteredRows
 }
 
-func isRowMatched(columns []Column, row Row, filter string) bool {
+func newContainsFilter(columns []Column, row Row, filter string) bool {
 	if filter == "" {
 		return true
 	}

--- a/table/filter.go
+++ b/table/filter.go
@@ -75,3 +75,74 @@ func isRowMatched(columns []Column, row Row, filter string) bool {
 
 	return !checkedAny
 }
+
+// NewFuzzyFilter returns a filterFunc that performs case-insensitive fuzzy
+// matching (subsequence) over the concatenation of all filterable column values.
+// Example wiring:
+//
+//	m.filterFunc = NewFuzzyFilter(m.columns)
+func NewFuzzyFilter(columns []Column) func(Row, string) bool {
+	return func(row Row, filter string) bool {
+		filter = strings.TrimSpace(filter)
+		if filter == "" {
+			return true
+		}
+
+		// Concatenate all filterable values for this row into one string
+		var b strings.Builder
+		for _, col := range columns {
+			if !col.filterable {
+				continue
+			}
+			if v, ok := row.Data[col.key]; ok {
+				// Unwrap StyledCell if present
+				switch vv := v.(type) {
+				case StyledCell:
+					v = vv.Data
+				}
+
+				switch vv := v.(type) {
+				case string:
+					b.WriteString(vv)
+				case fmt.Stringer:
+					b.WriteString(vv.String())
+				default:
+					b.WriteString(fmt.Sprintf("%v", v))
+				}
+				b.WriteByte(' ')
+			}
+		}
+
+		haystack := strings.ToLower(b.String())
+		if haystack == "" {
+			return false
+		}
+
+		// Support multi-token filters: "acme stl" must fuzzy-match both tokens
+		for _, token := range strings.Fields(strings.ToLower(filter)) {
+			if !fuzzySubsequenceMatch(haystack, token) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// fuzzySubsequenceMatch returns true if all runes in needle appear in order
+// within haystack (not necessarily contiguously). Case must be normalized by caller.
+func fuzzySubsequenceMatch(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	hi, ni := 0, 0
+	hr := []rune(haystack)
+	nr := []rune(needle)
+
+	for hi < len(hr) && ni < len(nr) {
+		if hr[hi] == nr[ni] {
+			ni++
+		}
+		hi++
+	}
+	return ni == len(nr)
+}

--- a/table/filter.go
+++ b/table/filter.go
@@ -14,14 +14,16 @@ func (m Model) getFilteredRows(rows []Row) []Row {
 	filteredRows := make([]Row, 0)
 
 	for _, row := range rows {
+		var availableFilterFunc func([]Column, Row, string) bool
+
 		if m.filterFunc != nil {
-			if m.filterFunc(row, filterInputValue) {
-				filteredRows = append(filteredRows, row)
-			}
+			availableFilterFunc = m.filterFunc
 		} else {
-			if isRowMatched(m.columns, row, filterInputValue) {
-				filteredRows = append(filteredRows, row)
-			}
+			availableFilterFunc = isRowMatched
+		}
+
+		if availableFilterFunc(m.columns, row, filterInputValue) {
+			filteredRows = append(filteredRows, row)
 		}
 	}
 
@@ -78,42 +80,40 @@ func isRowMatched(columns []Column, row Row, filter string) bool {
 
 // newFuzzyFilter returns a filterFunc that performs case-insensitive fuzzy
 // matching (subsequence) over the concatenation of all filterable column values.
-func newFuzzyFilter(columns []Column) func(Row, string) bool {
-	return func(row Row, filter string) bool {
-		filter = strings.TrimSpace(filter)
-		if filter == "" {
-			return true
-		}
-
-		var builder strings.Builder
-		for _, col := range columns {
-			if !col.Filterable() {
-				continue
-			}
-			value, ok := row.Data[col.Key()]
-			if !ok {
-				continue
-			}
-			if sc, ok := value.(StyledCell); ok {
-				value = sc.Data
-			}
-			builder.WriteString(fmt.Sprint(value)) // uses Stringer if implemented
-			builder.WriteByte(' ')
-		}
-
-		haystack := strings.ToLower(builder.String())
-		if haystack == "" {
-			return false
-		}
-
-		for _, token := range strings.Fields(strings.ToLower(filter)) {
-			if !fuzzySubsequenceMatch(haystack, token) {
-				return false
-			}
-		}
-
+func newFuzzyFilter(columns []Column, row Row, filter string) bool {
+	filter = strings.TrimSpace(filter)
+	if filter == "" {
 		return true
 	}
+
+	var builder strings.Builder
+	for _, col := range columns {
+		if !col.filterable {
+			continue
+		}
+		value, ok := row.Data[col.key]
+		if !ok {
+			continue
+		}
+		if sc, ok := value.(StyledCell); ok {
+			value = sc.Data
+		}
+		builder.WriteString(fmt.Sprint(value)) // uses Stringer if implemented
+		builder.WriteByte(' ')
+	}
+
+	haystack := strings.ToLower(builder.String())
+	if haystack == "" {
+		return false
+	}
+
+	for _, token := range strings.Fields(strings.ToLower(filter)) {
+		if !fuzzySubsequenceMatch(haystack, token) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // fuzzySubsequenceMatch returns true if all runes in needle appear in order

--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -16,37 +16,37 @@ func TestIsRowMatched(t *testing.T) {
 		NewColumn("title", "title", 10).WithFiltered(true),
 		NewColumn("description", "description", 10)}
 
-	assert.True(t, isRowMatched(columns,
+	assert.True(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"title":       "AAA",
 			"description": "",
 		}), ""))
 
-	assert.True(t, isRowMatched(columns,
+	assert.True(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"title":       "AAA",
 			"description": "",
 		}), "AA"))
 
-	assert.True(t, isRowMatched(columns,
+	assert.True(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"title":       "AAA",
 			"description": "",
 		}), "A"))
 
-	assert.True(t, isRowMatched(columns,
+	assert.True(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"title":       "AAA",
 			"description": "",
 		}), "a"))
 
-	assert.False(t, isRowMatched(columns,
+	assert.False(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"title":       "AAA",
 			"description": "",
 		}), "B"))
 
-	assert.False(t, isRowMatched(columns,
+	assert.False(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"title":       "AAA",
 			"description": "BBB",
@@ -54,14 +54,14 @@ func TestIsRowMatched(t *testing.T) {
 
 	timeFrom2020 := time.Date(2020, time.July, 1, 1, 1, 1, 1, time.UTC)
 
-	assert.True(t, isRowMatched(columns,
+	assert.True(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"title": timeFrom2020,
 		}),
 		"2020",
 	))
 
-	assert.False(t, isRowMatched(columns,
+	assert.False(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"title": timeFrom2020,
 		}),
@@ -75,13 +75,13 @@ func TestIsRowMatchedForStyled(t *testing.T) {
 		NewColumn("description", "description", 10),
 	}
 
-	assert.True(t, isRowMatched(columns,
+	assert.True(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"title":       "AAA",
 			"description": "",
 		}), "AA"))
 
-	assert.True(t, isRowMatched(columns,
+	assert.True(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"title":       NewStyledCell("AAA", lipgloss.NewStyle()),
 			"description": "",
@@ -93,22 +93,22 @@ func TestIsRowMatchedForNonStringer(t *testing.T) {
 		NewColumn("val", "val", 10).WithFiltered(true),
 	}
 
-	assert.True(t, isRowMatched(columns,
+	assert.True(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"val": 12,
 		}), "12"))
 
-	assert.True(t, isRowMatched(columns,
+	assert.True(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"val": 12,
 		}), "1"))
 
-	assert.True(t, isRowMatched(columns,
+	assert.True(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"val": 12,
 		}), "2"))
 
-	assert.False(t, isRowMatched(columns,
+	assert.False(t, newContainsFilter(columns,
 		NewRow(RowData{
 			"val": 12,
 		}), "3"))

--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -461,6 +461,32 @@ func TestFuzzyFilter_SubsequenceAcrossColumns(t *testing.T) {
 	}
 }
 
+func TestFuzzyFilter_ColumnNotInRow(t *testing.T) {
+	cols := []Column{
+		NewColumn("column_name_doesnt_match", "Name", 10).WithFiltered(true),
+	}
+	row := NewRow(RowData{
+		"name": "Acme Steel",
+	})
+
+	if filterFuncFuzzy(cols, row, "steel") {
+		t.Fatalf("did not expect 'steel' to match")
+	}
+}
+
+func TestFuzzyFilter_RowHasEmptyHaystack(t *testing.T) {
+	cols := []Column{
+		NewColumn("name", "Name", 10).WithFiltered(true),
+	}
+	row := NewRow(RowData{"name": ""})
+
+	// literally any value other than an empty string
+	// should not match
+	if filterFuncFuzzy(cols, row, "a") {
+		t.Fatalf("did not expect 'a' to match")
+	}
+}
+
 func TestFuzzyFilter_MultiToken_AND(t *testing.T) {
 	cols := []Column{
 		NewColumn("name", "Name", 10).WithFiltered(true),
@@ -518,5 +544,17 @@ func TestFuzzyFilter_NonStringValuesFormatted(t *testing.T) {
 
 	if !filterFuncFuzzy(cols, row, "245") { // subsequence of "12345"
 		t.Fatalf("expected matcher to format non-strings and match subsequence")
+	}
+}
+
+func TestFuzzySubSequenceMatch_EmptyString(t *testing.T) {
+	if !fuzzySubsequenceMatch("anything", "") {
+		t.Fatalf("empty needle should match anything")
+	}
+	if fuzzySubsequenceMatch("", "a") {
+		t.Fatalf("non-empty needle should not match empty haystack")
+	}
+	if !fuzzySubsequenceMatch("", "") {
+		t.Fatalf("empty needle should match empty haystack")
 	}
 }

--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -430,7 +430,7 @@ func TestFuzzyFilter_EmptyFilterMatchesAll(t *testing.T) {
 		NewRow(RowData{"name": "Globex"}),
 	}
 
-	ff := NewFuzzyFilter(cols)
+	ff := newFuzzyFilter(cols)
 
 	for i, r := range rows {
 		if !ff(r, "") {
@@ -449,18 +449,18 @@ func TestFuzzyFilter_SubsequenceAcrossColumns(t *testing.T) {
 		"city": "Stuttgart",
 	})
 
-	ff := NewFuzzyFilter(cols)
+	fuzzyFilter := newFuzzyFilter(cols)
 
 	// subsequence match: "agt" appears in order inside "stuttgart"
-	if !ff(row, "agt") {
+	if !fuzzyFilter(row, "agt") {
 		t.Fatalf("expected subsequence 'agt' to match 'Stuttgart'")
 	}
 	// case-insensitive
-	if !ff(row, "ACM") {
+	if !fuzzyFilter(row, "ACM") {
 		t.Fatalf("expected case-insensitive subsequence to match 'Acme'")
 	}
 	// not a subsequence
-	if ff(row, "zzt") {
+	if fuzzyFilter(row, "zzt") {
 		t.Fatalf("did not expect 'zzt' to match")
 	}
 }
@@ -475,13 +475,13 @@ func TestFuzzyFilter_MultiToken_AND(t *testing.T) {
 		"dept": "R&D",
 	})
 
-	ff := NewFuzzyFilter(cols)
+	fuzzyFilter := newFuzzyFilter(cols)
 
 	// Both tokens must match as subsequences somewhere in the concatenated haystack
-	if !ff(row, "wy ent") { // "wy" in Wayne, "ent" in Enterprises
+	if !fuzzyFilter(row, "wy ent") { // "wy" in Wayne, "ent" in Enterprises
 		t.Fatalf("expected multi-token AND to match")
 	}
-	if ff(row, "wy zzz") {
+	if fuzzyFilter(row, "wy zzz") {
 		t.Fatalf("expected multi-token AND to fail when a token doesn't match")
 	}
 }
@@ -496,7 +496,7 @@ func TestFuzzyFilter_IgnoresNonFilterableColumns(t *testing.T) {
 		"secret": "topsecretpattern",
 	})
 
-	ff := NewFuzzyFilter(cols)
+	ff := newFuzzyFilter(cols)
 
 	if ff(row, "topsecret") {
 		t.Fatalf("should not match on non-filterable column content")
@@ -511,7 +511,7 @@ func TestFuzzyFilter_UnwrapsStyledCell(t *testing.T) {
 		"name": NewStyledCell("Nakatomi Plaza", lipgloss.NewStyle()),
 	})
 
-	ff := NewFuzzyFilter(cols)
+	ff := newFuzzyFilter(cols)
 
 	if !ff(row, "nak plz") {
 		t.Fatalf("expected fuzzy subsequence to match within StyledCell data")
@@ -526,7 +526,7 @@ func TestFuzzyFilter_NonStringValuesFormatted(t *testing.T) {
 		"id": 12345, // should be formatted via fmt.Sprintf("%v", v)
 	})
 
-	ff := NewFuzzyFilter(cols)
+	ff := newFuzzyFilter(cols)
 
 	if !ff(row, "245") { // subsequence of "12345"
 		t.Fatalf("expected matcher to format non-strings and match subsequence")

--- a/table/model.go
+++ b/table/model.go
@@ -126,7 +126,7 @@ func New(columns []Column) Model {
 		unselectedText: "[ ]",
 
 		filterTextInput: filterInput,
-		filterFunc:      newContainsFilter,
+		filterFunc:      filterFuncContains,
 		baseStyle:       lipgloss.NewStyle().Align(lipgloss.Right),
 
 		paginationWrapping: true,

--- a/table/model.go
+++ b/table/model.go
@@ -78,7 +78,7 @@ type Model struct {
 	// Filter
 	filtered        bool
 	filterTextInput textinput.Model
-	filterFunc      func(Row, string) bool
+	filterFunc      func([]Column, Row, string) bool
 
 	// For flex columns
 	targetTotalWidth int
@@ -126,7 +126,7 @@ func New(columns []Column) Model {
 		unselectedText: "[ ]",
 
 		filterTextInput: filterInput,
-		filterFunc:      nil,
+		filterFunc:      isRowMatched,
 		baseStyle:       lipgloss.NewStyle().Align(lipgloss.Right),
 
 		paginationWrapping: true,

--- a/table/model.go
+++ b/table/model.go
@@ -126,7 +126,7 @@ func New(columns []Column) Model {
 		unselectedText: "[ ]",
 
 		filterTextInput: filterInput,
-		filterFunc:      isRowMatched,
+		filterFunc:      newContainsFilter,
 		baseStyle:       lipgloss.NewStyle().Align(lipgloss.Right),
 
 		paginationWrapping: true,

--- a/table/options.go
+++ b/table/options.go
@@ -376,10 +376,11 @@ func (m Model) WithFilterFunc(shouldInclude func(row Row, filterInput string) bo
 	return m
 }
 
-func (m Model) WithFuzzyFilter() Model {
-	m.filterFunc = NewFuzzyFilter(m.columns)
-
-	return m
+func (m Model) WithFuzzyFilter(activate bool) Model {
+	if activate {
+		return m.WithFilterFunc(newFuzzyFilter(m.columns))
+	}
+	return m.WithFilterFunc(nil)
 }
 
 // WithFooterVisibility sets the visibility of the footer.

--- a/table/options.go
+++ b/table/options.go
@@ -376,9 +376,9 @@ func (m Model) WithFilterFunc(shouldInclude func(columns []Column, row Row, filt
 	return m
 }
 
-// WithFuzzyFilter permanently enables fuzzy filtering for the table.
+// WithFuzzyFilter enables fuzzy filtering for the table.
 func (m Model) WithFuzzyFilter() Model {
-	return m.WithFilterFunc(newFuzzyFilter)
+	return m.WithFilterFunc(filterFuncFuzzy)
 }
 
 // WithFooterVisibility sets the visibility of the footer.

--- a/table/options.go
+++ b/table/options.go
@@ -368,7 +368,7 @@ func (m Model) WithFilterInputValue(value string) Model {
 // true, the row will be included in the filtered results. If the function
 // is nil, the function won't be used. The filter input is passed as the second
 // argument to the function.
-func (m Model) WithFilterFunc(shouldInclude func(row Row, filterInput string) bool) Model {
+func (m Model) WithFilterFunc(shouldInclude func(columns []Column, row Row, filterInput string) bool) Model {
 	m.filterFunc = shouldInclude
 
 	m.visibleRowCacheUpdated = false
@@ -376,11 +376,9 @@ func (m Model) WithFilterFunc(shouldInclude func(row Row, filterInput string) bo
 	return m
 }
 
-func (m Model) WithFuzzyFilter(activate bool) Model {
-	if activate {
-		return m.WithFilterFunc(newFuzzyFilter(m.columns))
-	}
-	return m.WithFilterFunc(nil)
+// WithFuzzyFilter permanently enables fuzzy filtering for the table.
+func (m Model) WithFuzzyFilter() Model {
+	return m.WithFilterFunc(newFuzzyFilter)
 }
 
 // WithFooterVisibility sets the visibility of the footer.

--- a/table/options.go
+++ b/table/options.go
@@ -376,6 +376,12 @@ func (m Model) WithFilterFunc(shouldInclude func(row Row, filterInput string) bo
 	return m
 }
 
+func (m Model) WithFuzzyFilter() Model {
+	m.filterFunc = NewFuzzyFilter(m.columns)
+
+	return m
+}
+
 // WithFooterVisibility sets the visibility of the footer.
 func (m Model) WithFooterVisibility(visibility bool) Model {
 	m.footerVisible = visibility


### PR DESCRIPTION
https://github.com/user-attachments/assets/7b873b59-ecb5-48b1-bd5a-d1bd28adeffb

I tried this one out in one of my personal projects, and it works nicely! 😄 

Fixes https://github.com/Evertras/bubble-table/issues/195

This also breaks the current `WithFilterFunc` API by requiring to pass `columns []Column` as first argument of the filtering function. This allows for more flexibility and integration of other filter methods.