### PR TITLE
feat: bump golangci-lint to v2.3.1

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,4 @@
-# https://golangci-lint.run/usage/linters/
-issues:
-  exclude-use-default: false
+version: "2"
 linters:
   enable:
     - asciicheck
@@ -12,36 +10,28 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
+    - err113
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
     - forbidigo
     - forcetypeassert
     - funlen
-    - gci
     - gocognit
     - goconst
     - gocyclo
     - godot
-    - goerr113
-    - gofmt
     - goheader
-    - goimports
-    - gomnd
     - gomoddirectives
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - importas
-    - ineffassign
     - ireturn
     - lll
     - makezero
     - misspell
+    - mnd
     - nakedret
     - nestif
     - nilerr
@@ -56,16 +46,38 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - stylecheck
     - tagliatelle
-    - tenv
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - varnamelen
     - wastedassign
     - whitespace
     - wrapcheck
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          allow:
+            - github.com/stretchr/testify/assert
+            - github.com/charmbracelet/lipgloss
+            - github.com/muesli/reflow/wordwrap
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ fmt: ./bin/gci
 	@./bin/gci write --skip-generated ./table/*.go
 
 ./bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.51.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v2.3.1
 
 ./bin/gci:
 	GOBIN=$(shell pwd)/bin go install github.com/daixiang0/gci@v0.9.1

--- a/table/calc.go
+++ b/table/calc.go
@@ -1,5 +1,8 @@
 package table
 
+// Keep compatibility with Go 1.21 by re-declaring min.
+//
+//nolint:predeclared
 func min(x, y int) int {
 	if x < y {
 		return x
@@ -8,6 +11,9 @@ func min(x, y int) int {
 	return y
 }
 
+// Keep compatibility with Go 1.21 by re-declaring max.
+//
+//nolint:predeclared
 func max(x, y int) int {
 	if x > y {
 		return x

--- a/table/data.go
+++ b/table/data.go
@@ -23,6 +23,7 @@ func asInt(data interface{}) (int64, bool) {
 		return val, true
 
 	case uint:
+		// #nosec: G115
 		return int64(val), true
 
 	case uint8:
@@ -35,6 +36,7 @@ func asInt(data interface{}) (int64, bool) {
 		return int64(val), true
 
 	case uint64:
+		// #nosec: G115
 		return int64(val), true
 
 	case time.Duration:

--- a/table/options_test.go
+++ b/table/options_test.go
@@ -177,7 +177,7 @@ func TestSelectRowsProgramatically(t *testing.T) {
 
 	tests := map[string]struct {
 		rows        []Row
-		selectedIds []int
+		selectedIDs []int
 	}{
 		"no rows selected": {
 			[]Row{
@@ -225,8 +225,8 @@ func TestSelectRowsProgramatically(t *testing.T) {
 			model := baseModel.WithRows(test.rows)
 			sel := model.SelectedRows()
 
-			assert.Equal(t, len(test.selectedIds), len(sel))
-			for i, id := range test.selectedIds {
+			assert.Equal(t, len(test.selectedIDs), len(sel))
+			for i, id := range test.selectedIDs {
 				assert.Equal(t, id, sel[i].Data[col], "expecting row %d to have same %s column value", i)
 			}
 

--- a/table/row.go
+++ b/table/row.go
@@ -53,24 +53,25 @@ func (r Row) WithStyle(style lipgloss.Style) Row {
 	return r
 }
 
-//nolint:nestif,cyclop // This has many ifs, but they're short
+//nolint:cyclop // This has many ifs, but they're short
 func (m Model) renderRowColumnData(row Row, column Column, rowStyle lipgloss.Style, borderStyle lipgloss.Style) string {
 	cellStyle := rowStyle.Copy().Inherit(column.style).Inherit(m.baseStyle)
 
 	var str string
 
-	if column.key == columnKeySelect {
+	switch column.key {
+	case columnKeySelect:
 		if row.selected {
 			str = m.selectedText
 		} else {
 			str = m.unselectedText
 		}
-	} else if column.key == columnKeyOverflowRight {
+	case columnKeyOverflowRight:
 		cellStyle = cellStyle.Align(lipgloss.Right)
 		str = ">"
-	} else if column.key == columnKeyOverflowLeft {
+	case columnKeyOverflowLeft:
 		str = "<"
-	} else {
+	default:
 		fmtString := "%v"
 
 		var data interface{}
@@ -137,7 +138,7 @@ func (m Model) renderBlankRow(last bool) string {
 // This is long and could use some refactoring in the future, but not quite sure
 // how to pick it apart yet.
 //
-//nolint:funlen, cyclop, gocognit
+//nolint:funlen, cyclop
 func (m Model) renderRowData(row Row, rowStyle lipgloss.Style, last bool) string {
 	numColumns := len(m.columns)
 

--- a/table/scrolling_fuzz_test.go
+++ b/table/scrolling_fuzz_test.go
@@ -14,7 +14,7 @@ import (
 
 // This is long because of test cases
 //
-//nolint:funlen,gocognit,cyclop
+//nolint:funlen,cyclop
 func FuzzHorizontalScrollingStopEdgeCases(f *testing.F) {
 	const (
 		minNameWidth = 2

--- a/table/scrolling_test.go
+++ b/table/scrolling_test.go
@@ -179,9 +179,7 @@ func TestHorizontalScrollingWithFooterAndFrozenCols(t *testing.T) {
 	assert.Equal(t, expectedTableOriginal, model.View())
 }
 
-// This is long due to literal strings
-//
-//nolint:funlen
+// This is long due to literal strings.
 func TestHorizontalScrollStopsAtLastColumnBeingVisible(t *testing.T) {
 	model := New([]Column{
 		NewColumn("Name", "Name", 4),

--- a/table/strlimit.go
+++ b/table/strlimit.go
@@ -18,6 +18,7 @@ func limitStr(str string, maxLen int) string {
 	}
 
 	if ansi.PrintableRuneWidth(str) > maxLen {
+		// #nosec: G115
 		return truncate.StringWithTail(str, uint(maxLen), "…")
 	}
 

--- a/table/view.go
+++ b/table/view.go
@@ -30,7 +30,7 @@ func (m Model) View() string {
 	if m.headerVisible {
 		rowStrs = append(rowStrs, headers)
 	} else if numRows > 0 || padding > 0 {
-		//nolint: gomnd // This is just getting the first newlined substring
+		//nolint: mnd // This is just getting the first newlined substring
 		split := strings.SplitN(headers, "\n", 2)
 		rowStrs = append(rowStrs, split[0])
 	}


### PR DESCRIPTION
Solves https://github.com/Evertras/bubble-table/issues/197 by bumping `golangci-lint` to `v2.3.1`, which is the latest as of today.
Some changes are arbitrary, some are due to the `golangci-lint migrate` command. Let's figure out what we should keep and what we should ignore :) 
