### PR TITLE
Update interface{} to any

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,4 +83,3 @@ fmt: ./bin/gci
 
 ./bin/gci:
 	GOBIN=$(shell pwd)/bin go install github.com/daixiang0/gci@v0.9.1
-

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ A table is defined by a list of `Column` values that define the columns in the
 table.  Each `Column` is associated with a unique string key.
 
 A table contains a list of `Row`s.  Each `Row` contains a `RowData` object which
-is simply a map of string column IDs to arbitrary `interface{}` data values.
+is simply a map of string column IDs to arbitrary `any` data values.
 When the table is rendered, each `Row` is checked for each `Column` key.  If the
 key exists in the `Row`'s `RowData`, it is rendered with `fmt.Sprintf("%v")`.
 If it does not exist, nothing is rendered.

--- a/table/cell.go
+++ b/table/cell.go
@@ -8,12 +8,12 @@ import "github.com/charmbracelet/lipgloss"
 // limited to colors, font style, and alignments - spacing style such as margin
 // will break the table format.
 type StyledCell struct {
-	Data  interface{}
+	Data  any
 	Style lipgloss.Style
 }
 
 // NewStyledCell creates an entry that can be set in the row data and show as
 // styled with the given style.
-func NewStyledCell(data interface{}, style lipgloss.Style) StyledCell {
+func NewStyledCell(data any, style lipgloss.Style) StyledCell {
 	return StyledCell{data, style}
 }

--- a/table/column.go
+++ b/table/column.go
@@ -64,7 +64,7 @@ func (c Column) WithFiltered(filterable bool) Column {
 // If not set, the default is "%v" for all data types.  Intended mainly for
 // numeric formatting.
 //
-// Since data is of the interface{} type, make sure that all data in the column
+// Since data is of the any type, make sure that all data in the column
 // is of the expected type or the format may fail.  For example, hardcoding '3'
 // instead of '3.0' and using '%.2f' will fail because '3' is an integer.
 func (c Column) WithFormatString(fmtString string) Column {

--- a/table/data.go
+++ b/table/data.go
@@ -5,7 +5,7 @@ import "time"
 // This is just a bunch of data type checks, so... no linting here
 //
 //nolint:cyclop
-func asInt(data interface{}) (int64, bool) {
+func asInt(data any) (int64, bool) {
 	switch val := data.(type) {
 	case int:
 		return int64(val), true
@@ -49,7 +49,7 @@ func asInt(data interface{}) (int64, bool) {
 	return 0, false
 }
 
-func asNumber(data interface{}) (float64, bool) {
+func asNumber(data any) (float64, bool) {
 	switch val := data.(type) {
 	case float32:
 		return float64(val), true

--- a/table/data_test.go
+++ b/table/data_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAsInt(t *testing.T) {
-	check := func(data interface{}, isInt bool, expectedValue int64) {
+	check := func(data any, isInt bool, expectedValue int64) {
 		val, ok := asInt(data)
 		assert.Equal(t, isInt, ok)
 		assert.Equal(t, expectedValue, val)
@@ -30,7 +30,7 @@ func TestAsInt(t *testing.T) {
 }
 
 func TestAsNumber(t *testing.T) {
-	check := func(data interface{}, isFloat bool, expectedValue float64) {
+	check := func(data any, isFloat bool, expectedValue float64) {
 		val, ok := asNumber(data)
 		assert.Equal(t, isFloat, ok)
 		assert.InDelta(t, expectedValue, val, 0.001)

--- a/table/events.go
+++ b/table/events.go
@@ -3,7 +3,7 @@ package table
 // UserEvent is some state change that has occurred due to user input.  These will
 // ONLY be generated when a user has interacted directly with the table.  These
 // will NOT be generated when code programmatically changes values in the table.
-type UserEvent interface{}
+type UserEvent any
 
 func (m *Model) appendUserEvent(e UserEvent) {
 	m.lastUpdateUserEvents = append(m.lastUpdateUserEvents, e)

--- a/table/model.go
+++ b/table/model.go
@@ -26,7 +26,7 @@ type Model struct {
 	visibleRowCache        []Row
 
 	// Shown when data is missing from a row
-	missingDataIndicator interface{}
+	missingDataIndicator any
 
 	// Interaction
 	focused bool

--- a/table/row.go
+++ b/table/row.go
@@ -8,12 +8,12 @@ import (
 	"github.com/muesli/reflow/wordwrap"
 )
 
-// RowData is a map of string column keys to interface{} data.  Data with a key
+// RowData is a map of string column keys to arbitrary data.  Data with a key
 // that matches a column key will be displayed.  Data with a key that does not
 // match a column key will not be displayed, but will remain attached to the Row.
 // This can be useful for attaching hidden metadata for future reference when
 // retrieving rows.
-type RowData map[string]interface{}
+type RowData map[string]any
 
 // Row represents a row in the table with some data keyed to the table columns>
 // Can have a style applied to it such as color/bold.  Create using NewRow().
@@ -32,7 +32,7 @@ var lastRowID uint32 = 1
 // NewRow creates a new row and copies the given row data.
 func NewRow(data RowData) Row {
 	row := Row{
-		Data: make(map[string]interface{}),
+		Data: make(map[string]any),
 		id:   lastRowID,
 	}
 
@@ -74,7 +74,7 @@ func (m Model) renderRowColumnData(row Row, column Column, rowStyle lipgloss.Sty
 	default:
 		fmtString := "%v"
 
-		var data interface{}
+		var data any
 
 		if entry, exists := row.Data[column.key]; exists {
 			data = entry


### PR DESCRIPTION
Minor update to use `any` instead of `interface{}` to better match updated Go standards and make a tool linter stop whining at me about it. :D