### PR TITLE
Add cell style func

### DIFF
--- a/examples/pokemon/main.go
+++ b/examples/pokemon/main.go
@@ -35,10 +35,24 @@ type Model struct {
 	pokeTable table.Model
 }
 
-func makeRow(name, element, colorStr string, numConversations int, positiveSentiment, negativeSentiment float32) table.Row {
+func makeRow(name, element string, numConversations int, positiveSentiment, negativeSentiment float32) table.Row {
+	elementStyleFunc := func(input table.StyledCellFuncInput) lipgloss.Style {
+		switch input.Data.(string) {
+		case "Fire":
+			return lipgloss.NewStyle().Foreground(lipgloss.Color(colorFire))
+		case "Water":
+			return lipgloss.NewStyle().Foreground(lipgloss.Color(colorWater))
+		case "Plant":
+			return lipgloss.NewStyle().Foreground(lipgloss.Color(colorPlant))
+		case "Electric":
+			return lipgloss.NewStyle().Foreground(lipgloss.Color(colorElectric))
+		default:
+			return lipgloss.NewStyle().Foreground(lipgloss.Color(colorNormal))
+		}
+	}
 	return table.NewRow(table.RowData{
 		columnKeyName:              name,
-		columnKeyElement:           table.NewStyledCell(element, lipgloss.NewStyle().Foreground(lipgloss.Color(colorStr))),
+		columnKeyElement:           table.NewStyledCellWithStyleFunc(element, elementStyleFunc),
 		columnKeyConversations:     numConversations,
 		columnKeyPositiveSentiment: positiveSentiment,
 		columnKeyNegativeSentiment: negativeSentiment,
@@ -58,13 +72,13 @@ func NewModel() Model {
 				WithStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("#c88"))).
 				WithFormatString("%.1f%%"),
 		}).WithRows([]table.Row{
-			makeRow("Pikachu", "Electric", colorElectric, 2300648, 21.9, 8.54),
-			makeRow("Eevee", "Normal", colorNormal, 636373, 26.4, 7.37),
-			makeRow("Bulbasaur", "Plant", colorPlant, 352190, 25.7, 9.02),
-			makeRow("Squirtle", "Water", colorWater, 241259, 25.6, 5.96),
-			makeRow("Blastoise", "Water", colorWater, 162794, 19.5, 6.04),
-			makeRow("Charmander", "Fire", colorFire, 265760, 31.2, 5.25),
-			makeRow("Charizard", "Fire", colorFire, 567763, 25.6, 7.56),
+			makeRow("Pikachu", "Electric", 2300648, 21.9, 8.54),
+			makeRow("Eevee", "Normal", 636373, 26.4, 7.37),
+			makeRow("Bulbasaur", "Plant", 352190, 25.7, 9.02),
+			makeRow("Squirtle", "Water", 241259, 25.6, 5.96),
+			makeRow("Blastoise", "Water", 162794, 19.5, 6.04),
+			makeRow("Charmander", "Fire", 265760, 31.2, 5.25),
+			makeRow("Charizard", "Fire", 567763, 25.6, 7.56),
 		}).
 			BorderRounded().
 			WithBaseStyle(styleBase).

--- a/table/cell.go
+++ b/table/cell.go
@@ -8,12 +8,47 @@ import "github.com/charmbracelet/lipgloss"
 // limited to colors, font style, and alignments - spacing style such as margin
 // will break the table format.
 type StyledCell struct {
-	Data  any
+	// Data is the content of the cell.
+	Data any
+
+	// Style is the specific style to apply. This is ignored if StyleFunc is not nil.
 	Style lipgloss.Style
+
+	// StyleFunc is a function that takes the row/column of the cell and
+	// returns a lipgloss.Style allowing for dynamic styling based on the cell's
+	// content or position. Overrides Style if set.
+	StyleFunc StyledCellFunc
 }
+
+// StyledCellFuncInput is the input to the StyledCellFunc. Sent as a struct
+// to allow for future additions without breaking changes.
+type StyledCellFuncInput struct {
+	// Data is the data in the cell.
+	Data any
+
+	// Column is the column that the cell belongs to.
+	Column Column
+}
+
+// StyledCellFunc is a function that takes various information about the cell and
+// returns a lipgloss.Style allowing for easier dynamic styling based on the cell's
+// content or position.
+type StyledCellFunc = func(input StyledCellFuncInput) lipgloss.Style
 
 // NewStyledCell creates an entry that can be set in the row data and show as
 // styled with the given style.
 func NewStyledCell(data any, style lipgloss.Style) StyledCell {
-	return StyledCell{data, style}
+	return StyledCell{
+		Data:  data,
+		Style: style,
+	}
+}
+
+// NewStyledCellWithStyleFunc creates an entry that can be set in the row data and show as
+// styled with the given style function.
+func NewStyledCellWithStyleFunc(data any, styleFunc StyledCellFunc) StyledCell {
+	return StyledCell{
+		Data:      data,
+		StyleFunc: styleFunc,
+	}
 }

--- a/table/row.go
+++ b/table/row.go
@@ -54,6 +54,7 @@ func (r Row) WithStyle(style lipgloss.Style) Row {
 }
 
 //nolint:cyclop // This has many ifs, but they're short
+//nolint:funlen // This function is just barely over the limit
 func (m Model) renderRowColumnData(row Row, column Column, rowStyle lipgloss.Style, borderStyle lipgloss.Style) string {
 	cellStyle := rowStyle.Copy().Inherit(column.style).Inherit(m.baseStyle)
 

--- a/table/row.go
+++ b/table/row.go
@@ -53,8 +53,7 @@ func (r Row) WithStyle(style lipgloss.Style) Row {
 	return r
 }
 
-//nolint:cyclop // This has many ifs, but they're short
-//nolint:funlen // This function is just barely over the limit
+//nolint:cyclop,funlen // Breaking this up will be more complicated than it's worth for now
 func (m Model) renderRowColumnData(row Row, column Column, rowStyle lipgloss.Style, borderStyle lipgloss.Style) string {
 	cellStyle := rowStyle.Copy().Inherit(column.style).Inherit(m.baseStyle)
 

--- a/table/row.go
+++ b/table/row.go
@@ -91,7 +91,15 @@ func (m Model) renderRowColumnData(row Row, column Column, rowStyle lipgloss.Sty
 		switch entry := data.(type) {
 		case StyledCell:
 			str = fmt.Sprintf(fmtString, entry.Data)
-			cellStyle = entry.Style.Copy().Inherit(cellStyle)
+
+			if entry.StyleFunc != nil {
+				cellStyle = entry.StyleFunc(StyledCellFuncInput{
+					Column: column,
+					Data:   entry.Data,
+				}).Copy().Inherit(cellStyle)
+			} else {
+				cellStyle = entry.Style.Copy().Inherit(cellStyle)
+			}
 		default:
 			str = fmt.Sprintf(fmtString, entry)
 		}


### PR DESCRIPTION
Similar to row style func, add a cell style func that takes in cell data and generate a style dynamically. This allows for easier styling of individual cells based on arbitrary criteria from the user, such as highlighting certain values or column selection.

Updates the pokemon example to highlight this, as generating rows no longer requires specific styling but instead we can highlight the elements based on value.

Should help solve https://github.com/Evertras/bubble-table/issues/201