### PR TITLE
Fix filter example when entering 'q' in the text box

### DIFF
--- a/examples/filter/main.go
+++ b/examples/filter/main.go
@@ -73,7 +73,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c", "q":
-			cmds = append(cmds, tea.Quit)
+			if !m.table.GetIsFilterInputFocused() {
+				cmds = append(cmds, tea.Quit)
+			}
 		}
 
 	}


### PR DESCRIPTION
Closes https://github.com/Evertras/bubble-table/issues/187

The example was erroneously quitting when hitting 'q'. Update the example with how this can be solved by checking if the filter input has focus.