### PR TITLE
Global metadata for style and filter funcs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ endif
 
 .PHONY: example-pokemon
 example-pokemon:
-	echo $(OS)
 	@go run ./examples/pokemon/*.go
 
 .PHONY: example-metadata

--- a/table/cell.go
+++ b/table/cell.go
@@ -31,6 +31,9 @@ type StyledCellFuncInput struct {
 
 	// Row is the row that the cell belongs to.
 	Row Row
+
+	// GlobalMetadata is the global table metadata that's been set by WithMetadata
+	GlobalMetadata map[string]any
 }
 
 // StyledCellFunc is a function that takes various information about the cell and

--- a/table/cell.go
+++ b/table/cell.go
@@ -32,7 +32,7 @@ type StyledCellFuncInput struct {
 	// Row is the row that the cell belongs to.
 	Row Row
 
-	// GlobalMetadata is the global table metadata that's been set by WithMetadata
+	// GlobalMetadata is the global table metadata that's been set by WithGlobalMetadata
 	GlobalMetadata map[string]any
 }
 

--- a/table/filter.go
+++ b/table/filter.go
@@ -8,9 +8,10 @@ import (
 // FilterFuncInput is the input to a FilterFunc. It's a struct so we can add more things later
 // without breaking compatibility.
 type FilterFuncInput struct {
-	Columns []Column
-	Row     Row
-	Filter  string
+	Columns        []Column
+	Row            Row
+	GlobalMetadata map[string]any
+	Filter         string
 }
 
 // FilterFunc takes a FilterFuncInput and returns true if the row should be visible,
@@ -35,9 +36,10 @@ func (m Model) getFilteredRows(rows []Row) []Row {
 		}
 
 		if availableFilterFunc(FilterFuncInput{
-			Columns: m.columns,
-			Row:     row,
-			Filter:  filterInputValue,
+			Columns:        m.columns,
+			Row:            row,
+			Filter:         filterInputValue,
+			GlobalMetadata: m.metadata,
 		}) {
 			filteredRows = append(filteredRows, row)
 		}

--- a/table/filter.go
+++ b/table/filter.go
@@ -8,10 +8,17 @@ import (
 // FilterFuncInput is the input to a FilterFunc. It's a struct so we can add more things later
 // without breaking compatibility.
 type FilterFuncInput struct {
-	Columns        []Column
-	Row            Row
+	// Columns is a list of the columns of the table
+	Columns []Column
+
+	// Row is the row that's being considered for filtering
+	Row Row
+
+	// GlobalMetadata is an arbitrary set of metadata from the table set by WithGlobalMetadata
 	GlobalMetadata map[string]any
-	Filter         string
+
+	// Filter is the filter string input to consider
+	Filter string
 }
 
 // FilterFunc takes a FilterFuncInput and returns true if the row should be visible,

--- a/table/filter_test.go
+++ b/table/filter_test.go
@@ -302,11 +302,13 @@ func TestFilterFunc(t *testing.T) {
 		// Completely arbitrary check for testing purposes
 		title := fmt.Sprintf("%v", input.Row.Data["title"])
 
-		return title == "AAA" && input.Filter == "x"
+		return title == "AAA" && input.Filter == "x" && input.GlobalMetadata["testValue"] == 3
 	}
 
 	// First check that the table won't match with different case
-	model := New(columns).WithRows(rows).Filtered(true)
+	model := New(columns).WithRows(rows).Filtered(true).WithGlobalMetadata(map[string]any{
+		"testValue": 3,
+	})
 	model = model.WithFilterInputValue("x")
 
 	filteredRows := model.getFilteredRows(rows)

--- a/table/model.go
+++ b/table/model.go
@@ -18,8 +18,9 @@ var (
 // Model is the main table model.  Create using New().
 type Model struct {
 	// Data
-	columns []Column
-	rows    []Row
+	columns  []Column
+	rows     []Row
+	metadata map[string]any
 
 	// Caches for optimizations
 	visibleRowCacheUpdated bool
@@ -116,6 +117,7 @@ func New(columns []Column) Model {
 	filterInput.Prompt = "/"
 	model := Model{
 		columns:        make([]Column, len(columns)),
+		metadata:       make(map[string]any),
 		highlightStyle: defaultHighlightStyle.Copy(),
 		border:         borderDefault,
 		headerVisible:  true,

--- a/table/options.go
+++ b/table/options.go
@@ -501,8 +501,8 @@ func (m Model) WithAdditionalFullHelpKeys(keys []key.Binding) Model {
 }
 
 // WithGlobalMetadata applies the given metadata to the table. This metadata is passed to
-// some functions such as FilterFuncInput and StyleFuncInput to enable more advanced decisions,
-// such as setting some global theme variable to reference, etc.
+// some functions in FilterFuncInput and StyleFuncInput to enable more advanced decisions,
+// such as setting some global theme variable to reference, etc. Has no effect otherwise.
 func (m Model) WithGlobalMetadata(metadata map[string]any) Model {
 	m.metadata = metadata
 

--- a/table/options.go
+++ b/table/options.go
@@ -499,3 +499,12 @@ func (m Model) WithAdditionalFullHelpKeys(keys []key.Binding) Model {
 
 	return m
 }
+
+// WithGlobalMetadata applies the given metadata to the table. This metadata is passed to
+// some functions such as FilterFuncInput and StyleFuncInput to enable more advanced decisions,
+// such as setting some global theme variable to reference, etc.
+func (m Model) WithGlobalMetadata(metadata map[string]any) Model {
+	m.metadata = metadata
+
+	return m
+}

--- a/table/row.go
+++ b/table/row.go
@@ -94,9 +94,10 @@ func (m Model) renderRowColumnData(row Row, column Column, rowStyle lipgloss.Sty
 
 			if entry.StyleFunc != nil {
 				cellStyle = entry.StyleFunc(StyledCellFuncInput{
-					Column: column,
-					Data:   entry.Data,
-					Row:    row,
+					Column:         column,
+					Data:           entry.Data,
+					Row:            row,
+					GlobalMetadata: m.metadata,
 				}).Copy().Inherit(cellStyle)
 			} else {
 				cellStyle = entry.Style.Copy().Inherit(cellStyle)

--- a/table/view_test.go
+++ b/table/view_test.go
@@ -803,7 +803,10 @@ func TestSimple3x3CellStyleFuncOverridesAsBaseColumnRowCell(t *testing.T) {
 		NewColumn("1", "1", 6),
 		NewColumn("2", "2", 6).WithStyle(lipgloss.NewStyle().Align(lipgloss.Left)),
 		NewColumn("3", "3", 6),
-	}).WithBaseStyle(lipgloss.NewStyle().Align(lipgloss.Center))
+	}).WithBaseStyle(lipgloss.NewStyle().Align(lipgloss.Center)).
+		WithGlobalMetadata(map[string]any{
+			"testValue": 37,
+		})
 
 	rows := []Row{}
 
@@ -826,6 +829,7 @@ func TestSimple3x3CellStyleFuncOverridesAsBaseColumnRowCell(t *testing.T) {
 		assert.Equal(t, "2", input.Column.Key(), "Wrong column key given to style func")
 		assert.Equal(t, "R", input.Data, "Wrong data given to style func")
 		assert.Equal(t, "1,1", input.Row.Data["1"], "Wrong row given to style func")
+		assert.Equal(t, 37, input.GlobalMetadata["testValue"], "Wrong table metadata given to style func")
 
 		return lipgloss.NewStyle().Align(lipgloss.Right)
 	})


### PR DESCRIPTION
Helps cleanly solve #201 as well as offer new possibilities generally for style and filter funcs. For example, a user could have a global metadata for a theme variable that a style func could reference, or a filter func might check a global case-insensitive metadata variable.

Updates the pokemon example to show an example of how this can be useful.