### PR TITLE
feat(#192): add WithRowBorder and WithOuterBorder

### DIFF
--- a/examples/rowborder/README.md
+++ b/examples/rowborder/README.md
@@ -1,0 +1,5 @@
+# Row Border Example
+
+This example demonstrates the `WithRowBorder` option, which draws a horizontal
+separator line between each data row to create a grid-like appearance. The
+example shows the feature with both the default and rounded border styles.

--- a/examples/rowborder/main.go
+++ b/examples/rowborder/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/evertras/bubble-table/table"
+)
+
+const (
+	columnKeyName    = "name"
+	columnKeyElement = "element"
+	columnKeyHP      = "hp"
+)
+
+type Model struct {
+	tables       []table.Model
+	tableLabels  []string
+	currentTable int
+}
+
+func NewModel() Model {
+	columns := []table.Column{
+		table.NewColumn(columnKeyName, "Name", 12),
+		table.NewColumn(columnKeyElement, "Element", 10),
+		table.NewColumn(columnKeyHP, "HP", 6),
+	}
+
+	rows := []table.Row{
+		table.NewRow(table.RowData{
+			columnKeyName:    "Bulbasaur",
+			columnKeyElement: "Grass",
+			columnKeyHP:      45,
+		}),
+		table.NewRow(table.RowData{
+			columnKeyName:    "Charmander",
+			columnKeyElement: "Fire",
+			columnKeyHP:      39,
+		}),
+		table.NewRow(table.RowData{
+			columnKeyName:    "Squirtle",
+			columnKeyElement: "Water",
+			columnKeyHP:      44,
+		}),
+		table.NewRow(table.RowData{
+			columnKeyName:    "Pikachu",
+			columnKeyElement: "Electric",
+			columnKeyHP:      35,
+		}),
+	}
+
+	return Model{
+		tables: []table.Model{
+			table.New(columns).WithRows(rows).WithRowBorder(true),
+			table.New(columns).WithRows(rows).WithRowBorder(true).BorderRounded(),
+			table.New(columns).WithRows(rows).WithRowBorder(true).WithOuterBorder(false),
+		},
+		tableLabels: []string{
+			"Default border",
+			"Rounded border",
+			"No outer border",
+		},
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc", "q":
+			return m, tea.Quit
+		case "left":
+			m.currentTable = (m.currentTable - 1 + len(m.tables)) % len(m.tables)
+		case "right":
+			m.currentTable = (m.currentTable + 1) % len(m.tables)
+		}
+	}
+
+	return m, nil
+}
+
+func (m Model) View() tea.View {
+	label := m.tableLabels[m.currentTable]
+	position := fmt.Sprintf("%d/%d", m.currentTable+1, len(m.tables))
+
+	header := fmt.Sprintf("Row border example  [← →] cycle  [q] quit\n%s (%s)\n\n", label, position)
+
+	return tea.NewView(header + m.tables[m.currentTable].View())
+}
+
+func main() {
+	p := tea.NewProgram(NewModel())
+
+	if _, err := p.Run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/table/border.go
+++ b/table/border.go
@@ -176,6 +176,12 @@ func (b *Border) buildSeparatorLine(columnWidths []int) string {
 	return b.buildBorderLine(columnWidths, b.LeftJunction, b.Bottom, b.InnerJunction, b.RightJunction)
 }
 
+// buildInnerSeparatorLine builds a separator line with no outer junction
+// characters, used when the outer border is hidden.
+func (b *Border) buildInnerSeparatorLine(columnWidths []int) string {
+	return b.buildBorderLine(columnWidths, "", b.Bottom, b.InnerJunction, "")
+}
+
 // buildBottomBorderLine builds the bottom border line for a multi-column
 // table. When hasFooter is true the corners are replaced with junctions so
 // the footer can attach below.
@@ -430,6 +436,11 @@ func (m Model) styleHeaders() borderStyleRow {
 
 	styles.inherit(m.headerStyle)
 
+	if !m.outerBorder {
+		styles.left = styles.left.BorderLeft(false)
+		styles.right = styles.right.BorderRight(false)
+	}
+
 	return styles
 }
 
@@ -460,6 +471,13 @@ func (m Model) styleRows() (inner borderStyleRow, last borderStyleRow) {
 			last.left = m.border.styleLeftWithFooter(last.left)
 			last.right = m.border.styleRightWithFooter(last.right)
 		}
+	}
+
+	if !m.outerBorder {
+		inner.left = inner.left.BorderLeft(false)
+		inner.right = inner.right.BorderRight(false)
+		last.left = last.left.BorderLeft(false)
+		last.right = last.right.BorderRight(false)
 	}
 
 	return inner, last

--- a/table/header.go
+++ b/table/header.go
@@ -106,23 +106,32 @@ func (m Model) renderHeaders() string {
 
 	headerBlock := lipgloss.JoinHorizontal(lipgloss.Bottom, headerStrings...)
 
-	// Build the top border line as a plain string using the recorded content widths.
-	topLine := m.border.buildTopBorderLine(renderedColWidths)
-
-	// Determine the last line of the header block:
-	//  - If data rows follow, use a separator (junction characters).
-	//  - If no rows follow and no footer, use the bottom border (corner characters).
-	//  - If no rows follow but a footer follows, use a separator so the footer
-	//    can attach cleanly.
 	hasRows := len(m.GetVisibleRows()) > 0 || m.calculatePadding(0) > 0
 
-	var lastLine string
+	return m.assembleHeaderOutput(headerBlock, renderedColWidths, hasRows)
+}
 
-	if hasRows {
-		lastLine = m.border.buildSeparatorLine(renderedColWidths)
-	} else {
-		lastLine = m.border.buildBottomBorderLine(renderedColWidths, m.hasFooter())
+func (m Model) assembleHeaderOutput(headerBlock string, renderedColWidths []int, hasRows bool) string {
+	if m.outerBorder {
+		var lastLine string
+		if hasRows {
+			lastLine = m.border.buildSeparatorLine(renderedColWidths)
+		} else {
+			lastLine = m.border.buildBottomBorderLine(renderedColWidths, m.hasFooter())
+		}
+		topLine := m.border.buildTopBorderLine(renderedColWidths)
+
+		return strings.Join([]string{topLine, headerBlock, lastLine}, "\n")
 	}
 
-	return strings.Join([]string{topLine, headerBlock, lastLine}, "\n")
+	var lastLine string
+	if hasRows {
+		lastLine = m.border.buildInnerSeparatorLine(renderedColWidths)
+	}
+
+	if lastLine != "" {
+		return strings.Join([]string{headerBlock, lastLine}, "\n")
+	}
+
+	return headerBlock
 }

--- a/table/model.go
+++ b/table/model.go
@@ -113,6 +113,12 @@ type Model struct {
 
 	// If true, the table will be multiline
 	multiline bool
+
+	// If true, draw a horizontal separator line between each data row
+	rowSeparator bool
+
+	// If true, render the outer border (top line, bottom line, left/right cell borders)
+	outerBorder bool
 }
 
 // New creates a new table ready for further modifications.
@@ -133,6 +139,7 @@ func New(columns []Column) Model {
 		metadata:       make(map[string]any),
 		highlightStyle: defaultHighlightStyle,
 		border:         borderDefault,
+		outerBorder:    true,
 		headerVisible:  true,
 		footerVisible:  true,
 		keyMap:         DefaultKeyMap(),

--- a/table/options.go
+++ b/table/options.go
@@ -258,6 +258,22 @@ func (m Model) WithBorderForeground(c color.Color) Model {
 	return m
 }
 
+// WithOuterBorder controls whether the outer border of the table is rendered
+// (top line, bottom line, and left/right cell borders). Defaults to true.
+func (m Model) WithOuterBorder(show bool) Model {
+	m.outerBorder = show
+
+	return m
+}
+
+// WithRowBorder controls whether a horizontal separator line is drawn between
+// each pair of data rows, creating a grid-like appearance.
+func (m Model) WithRowBorder(show bool) Model {
+	m.rowSeparator = show
+
+	return m
+}
+
 // WithTargetWidth sets the total target width of the table, including borders.
 // This only takes effect when using flex columns.  When using flex columns,
 // columns will stretch to fill out to the total width given here.

--- a/table/row.go
+++ b/table/row.go
@@ -124,7 +124,7 @@ func (m Model) renderRowColumnData(row Row, column Column, rowStyle lipgloss.Sty
 	return cellStr
 }
 
-func (m Model) renderRow(rowIndex int, last bool) string {
+func (m Model) renderRow(rowIndex int, last bool, separatorBelow bool) string {
 	row := m.GetVisibleRows()[rowIndex]
 	highlighted := rowIndex == m.rowCursorIndex
 
@@ -142,18 +142,18 @@ func (m Model) renderRow(rowIndex int, last bool) string {
 		rowStyle = rowStyle.Inherit(m.highlightStyle)
 	}
 
-	return m.renderRowData(row, rowStyle, last)
+	return m.renderRowData(row, rowStyle, last, separatorBelow)
 }
 
 func (m Model) renderBlankRow(last bool) string {
-	return m.renderRowData(NewRow(nil), lipgloss.NewStyle(), last)
+	return m.renderRowData(NewRow(nil), lipgloss.NewStyle(), last, false)
 }
 
 // This is long and could use some refactoring in the future, but not quite sure
 // how to pick it apart yet.
 //
 //nolint:funlen, cyclop
-func (m Model) renderRowData(row Row, rowStyle lipgloss.Style, last bool) string {
+func (m Model) renderRowData(row Row, rowStyle lipgloss.Style, last bool, separatorBelow bool) string {
 	numColumns := len(m.columns)
 
 	columnStrings := []string{}
@@ -251,11 +251,29 @@ func (m Model) renderRowData(row Row, rowStyle lipgloss.Style, last bool) string
 
 	rowLine := lipgloss.JoinHorizontal(lipgloss.Bottom, columnStrings...)
 
-	if last {
-		// Append the bottom border line as a plain string.
-		bottomLine := m.border.buildBottomBorderLine(renderedColWidths, m.hasFooter())
+	return m.assembleRowOutput(rowLine, renderedColWidths, last, separatorBelow)
+}
 
-		return rowLine + "\n" + bottomLine
+func (m Model) assembleRowOutput(rowLine string, renderedColWidths []int, last, separatorBelow bool) string {
+	if last {
+		if m.outerBorder {
+			bottomLine := m.border.buildBottomBorderLine(renderedColWidths, m.hasFooter())
+
+			return rowLine + "\n" + bottomLine
+		}
+
+		return rowLine
+	}
+
+	if separatorBelow {
+		var sepLine string
+		if m.outerBorder {
+			sepLine = m.border.buildSeparatorLine(renderedColWidths)
+		} else {
+			sepLine = m.border.buildInnerSeparatorLine(renderedColWidths)
+		}
+
+		return rowLine + "\n" + sepLine
 	}
 
 	return rowLine

--- a/table/view.go
+++ b/table/view.go
@@ -36,7 +36,9 @@ func (m Model) View() string {
 	}
 
 	for i := startRowIndex; i <= endRowIndex; i++ {
-		rowStrs = append(rowStrs, m.renderRow(i, padding == 0 && i == endRowIndex))
+		isLast := padding == 0 && i == endRowIndex
+		separatorBelow := m.rowSeparator && i < endRowIndex
+		rowStrs = append(rowStrs, m.renderRow(i, isLast, separatorBelow))
 	}
 
 	for i := 1; i <= padding; i++ {

--- a/table/view_test.go
+++ b/table/view_test.go
@@ -1741,3 +1741,184 @@ func TestMultilineDisabledExplicite(t *testing.T) {
 	rendered := model.View()
 	assert.Equal(t, expectedTable, rendered)
 }
+
+func TestRowBorder3x3(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+		NewColumn("3", "3", 4),
+	}).WithRowBorder(true)
+
+	rows := []Row{}
+
+	for rowIndex := 1; rowIndex <= 3; rowIndex++ {
+		rowData := RowData{}
+
+		for columnIndex := 1; columnIndex <= 3; columnIndex++ {
+			id := fmt.Sprintf("%d", columnIndex)
+			rowData[id] = fmt.Sprintf("%d,%d", columnIndex, rowIndex)
+		}
+
+		rows = append(rows, NewRow(rowData))
+	}
+
+	model = model.WithRows(rows)
+
+	const expectedTable = `┏━━━━┳━━━━┳━━━━┓
+┃   1┃   2┃   3┃
+┣━━━━╋━━━━╋━━━━┫
+┃ 1,1┃ 2,1┃ 3,1┃
+┣━━━━╋━━━━╋━━━━┫
+┃ 1,2┃ 2,2┃ 3,2┃
+┣━━━━╋━━━━╋━━━━┫
+┃ 1,3┃ 2,3┃ 3,3┃
+┗━━━━┻━━━━┻━━━━┛`
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
+func TestRowBorderSingleRowNoSeparator(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+	}).WithRows([]Row{
+		NewRow(RowData{"1": "a", "2": "b"}),
+	}).WithRowBorder(true)
+
+	const expectedTable = `┏━━━━┳━━━━┓
+┃   1┃   2┃
+┣━━━━╋━━━━┫
+┃   a┃   b┃
+┗━━━━┻━━━━┛`
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
+func TestRowBorderRounded(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+	}).WithRows([]Row{
+		NewRow(RowData{"1": "a", "2": "b"}),
+		NewRow(RowData{"1": "c", "2": "d"}),
+	}).WithRowBorder(true).BorderRounded()
+
+	const expectedTable = `╭────┬────╮
+│   1│   2│
+├────┼────┤
+│   a│   b│
+├────┼────┤
+│   c│   d│
+╰────┴────╯`
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
+func TestOuterBorderHidden(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+	}).WithRows([]Row{
+		NewRow(RowData{"1": "a", "2": "b"}),
+		NewRow(RowData{"1": "c", "2": "d"}),
+	}).WithOuterBorder(false)
+
+	const expectedTable = "   1┃   2\n━━━━╋━━━━\n   a┃   b\n   c┃   d"
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
+func TestOuterBorderHiddenWithRowBorder(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+	}).WithRows([]Row{
+		NewRow(RowData{"1": "a", "2": "b"}),
+		NewRow(RowData{"1": "c", "2": "d"}),
+	}).WithOuterBorder(false).WithRowBorder(true)
+
+	const expectedTable = "   1┃   2\n━━━━╋━━━━\n   a┃   b\n━━━━╋━━━━\n   c┃   d"
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
+func TestOuterBorderHiddenRounded(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+	}).WithRows([]Row{
+		NewRow(RowData{"1": "a", "2": "b"}),
+		NewRow(RowData{"1": "c", "2": "d"}),
+	}).WithOuterBorder(false).BorderRounded()
+
+	const expectedTable = "   1│   2\n────┼────\n   a│   b\n   c│   d"
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
+func TestOuterBorderHiddenNoRows(t *testing.T) {
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+	}).WithOuterBorder(false)
+
+	const expectedTable = "   1┃   2"
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}
+
+func TestOuterBorderTrueMatchesDefault(t *testing.T) {
+	cols := []Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+	}
+	rows := []Row{
+		NewRow(RowData{"1": "a", "2": "b"}),
+		NewRow(RowData{"1": "c", "2": "d"}),
+	}
+
+	assert.Equal(t,
+		New(cols).WithRows(rows).View(),
+		New(cols).WithRows(rows).WithOuterBorder(true).View(),
+	)
+}
+
+func TestRowBorderNoSeparatorBeforePaddingRows(t *testing.T) {
+	// WithMinimumHeight(7) with 2 data rows produces 1 padding row.
+	// The separator should appear between the two data rows but NOT
+	// between the last data row and the blank padding row.
+	model := New([]Column{
+		NewColumn("1", "1", 4),
+		NewColumn("2", "2", 4),
+	}).WithRows([]Row{
+		NewRow(RowData{"1": "a", "2": "b"}),
+		NewRow(RowData{"1": "c", "2": "d"}),
+	}).WithRowBorder(true).WithMinimumHeight(7)
+
+	const expectedTable = `┏━━━━┳━━━━┓
+┃   1┃   2┃
+┣━━━━╋━━━━┫
+┃   a┃   b┃
+┣━━━━╋━━━━┫
+┃   c┃   d┃
+┃    ┃    ┃
+┗━━━━┻━━━━┛`
+
+	rendered := model.View()
+
+	assert.Equal(t, expectedTable, rendered)
+}


### PR DESCRIPTION
### Summary
- `WithRowBorder(true)` adds an inner border to the cells, giving a grid-like appearance.
- `WithOuterBorder(false)` hides the outer border.

Feature requested in #192 

### Example

```
Default border:
┏━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━┓
┃        Name┃   Element┃    HP┃
┣━━━━━━━━━━━━╋━━━━━━━━━━╋━━━━━━┫
┃   Bulbasaur┃     Grass┃    45┃
┣━━━━━━━━━━━━╋━━━━━━━━━━╋━━━━━━┫
┃  Charmander┃      Fire┃    39┃
┣━━━━━━━━━━━━╋━━━━━━━━━━╋━━━━━━┫
┃    Squirtle┃     Water┃    44┃
┣━━━━━━━━━━━━╋━━━━━━━━━━╋━━━━━━┫
┃     Pikachu┃  Electric┃    35┃
┗━━━━━━━━━━━━┻━━━━━━━━━━┻━━━━━━┛
```

```
No outer border (3/3)

        Name┃   Element┃    HP
━━━━━━━━━━━━╋━━━━━━━━━━╋━━━━━━
   Bulbasaur┃     Grass┃    45
━━━━━━━━━━━━╋━━━━━━━━━━╋━━━━━━
  Charmander┃      Fire┃    39
━━━━━━━━━━━━╋━━━━━━━━━━╋━━━━━━
    Squirtle┃     Water┃    44
━━━━━━━━━━━━╋━━━━━━━━━━╋━━━━━━
     Pikachu┃  Electric┃    35
```